### PR TITLE
Report error messages with std::cerr

### DIFF
--- a/lexer.l
+++ b/lexer.l
@@ -40,7 +40,7 @@ operator [-+*/]
 \n {}
 
 . {
-    std::cout << "Invalid input: " << yytext << std::endl;
+    std::cerr << "Invalid input: " << yytext << std::endl;
     std::exit(-1);
   }
 

--- a/parser.y
+++ b/parser.y
@@ -60,7 +60,7 @@ epsilon: /* empty */ ;
 %%
 
 void yy::parser::error(const std::string& err) {
-  std::cout << err << std::endl;
+  std::cerr << err << std::endl;
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This separates normal outputs from error messages so that redirections (>) can be better exploited.