### PR TITLE
Fix undefined symbols in header file of parser

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -2,15 +2,22 @@
 
 #include <fstream>
 #include <iostream>
-#include <memory>
-#include <string>
 #include <utility>
 
-#include "ast.cpp"
 #include "lex.yy.c"
 
 std::ofstream output;
 %}
+
+// Dependency code required for the value and location types;
+// inserts verbatim to the header file.
+%code requires {
+  #include <memory>
+  #include <string>
+  #include <vector>
+
+  #include "ast.cpp"
+}
 
 %skeleton "lalr1.cc"
 %require "3.2"


### PR DESCRIPTION
The value types, e.g., `std::unique_ptr<...>`, are referenced in the header file of parser, _y.tab.c_, without inserting the includes specified in the prologue (the `%{ %}` block at the top of the file).
This causes error when including the header file without directly linking the implementation.
To resolve this, add a `%code requires {}` block. The codes inside that block are inserted verbatim to the header file.
This PR also fixes the missing include of `vector`.

See also:
- [Prologue Alternatives - Bison Manual](https://www.gnu.org/software/bison/manual/html_node/Prologue-Alternatives.html)
- [%code Summary - Bison Manual](https://www.gnu.org/software/bison/manual/html_node/_0025code-Summary.html)