### PR TITLE
Convert ast file to header file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all: $(TARGET) test
 test: $(TARGET)
 	make -C test/
 
-$(TARGET): lex.yy.c y.tab.c ast.cpp
+$(TARGET): lex.yy.c y.tab.c ast.hpp
 	$(CXX) $(CXXFLAG) y.tab.c -o $@
 
 lex.yy.c: lexer.l

--- a/ast.hpp
+++ b/ast.hpp
@@ -1,3 +1,6 @@
+#ifndef AST_HPP_
+#define AST_HPP_
+
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -244,3 +247,5 @@ static const char* Pad(int n) {
   }
   return padding + (80 - n);
 }
+
+#endif  // AST_HPP_

--- a/parser.y
+++ b/parser.y
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <utility>
 
+#include "ast.hpp"
 #include "lex.yy.c"
 
 std::ofstream output;


### PR DESCRIPTION
The _ast.cpp_ file provides classes or functions that are meant to be includes by others, such as _parser.y_.
It should be a header file rather than an implementation file.