### PR TITLE
Ignore Python environments & VS Code configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,15 @@ lex.yy.*
 
 # QBE IR files
 *.ssa
+
+# Python environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# VS Code configs
+.vscode


### PR DESCRIPTION
Python environments are associated with our testing tool and the VS Code configurations are specific to my personal use of the editor. To maintain cleaner version control, these elements are being ignored.
For shared configurations, we can utilize the [.editorconfig](https://editorconfig.org/) file.

Feel free to extend the list of exclusions if there are additional editor-specific configurations that need to be ignored!