### PR TITLE
Move parser driver to main.cpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ all: $(TARGET) test
 test: $(TARGET)
 	make -C test/
 
-$(TARGET): lex.yy.c y.tab.c ast.hpp
-	$(CXX) $(CXXFLAG) y.tab.c -o $@
+$(TARGET): main.cpp lex.yy.c y.tab.c ast.hpp
+	$(CXX) $(CXXFLAG) $< y.tab.c -o $@
 
 lex.yy.c: lexer.l
 	$(LEX) -o $@ $^

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,20 @@
+#include <fstream>
+
+#include "y.tab.h"
+
+/// @brief Where the generated code goes.
+std::ofstream output;
+
+extern void yylex_destroy();
+
+int main(int argc, char** argv) {
+  /* TODO: read input parameter */
+  output.open("test.ssa");
+  yy::parser parser{};
+  int ret = parser.parse();
+
+  yylex_destroy();
+  output.close();
+
+  return ret;
+}

--- a/parser.y
+++ b/parser.y
@@ -6,7 +6,7 @@
 
 #include "lex.yy.c"
 
-std::ofstream output;
+extern std::ofstream output;
 %}
 
 // Dependency code required for the value and location types;
@@ -110,16 +110,4 @@ epsilon: /* empty */ ;
 
 void yy::parser::error(const std::string& err) {
   std::cerr << err << std::endl;
-}
-
-int main(int argc, char **argv) {
-  /* TODO: read input parameter */
-  output.open("test.ssa");
-  yy::parser parser{};
-  int ret = parser.parse();
-
-  yylex_destroy();
-  output.close();
-
-  return ret;
 }


### PR DESCRIPTION
By relocating the parser driver to _main.cpp_, we enhance its autonomy in handling compiler options and other non-parser-related logic.
This separation contributes to a clearer and more modular code structure.