### PR TITLE
Move analysis and transformation outside parser

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/ast.hpp
+++ b/ast.hpp
@@ -275,7 +275,7 @@ class BinaryExprNode : public ExprNode {
               << std::endl;
   }
 
-  void CheckType(ScopeStack& env) {
+  void CheckType(ScopeStack& env) override {
     lhs_->CheckType(env);
     rhs_->CheckType(env);
     if (lhs_->type != rhs_->type) {

--- a/main.cpp
+++ b/main.cpp
@@ -1,9 +1,14 @@
 #include <fstream>
+#include <memory>
 
+#include "ast.hpp"
+#include "scope.hpp"
 #include "y.tab.h"
 
 /// @brief Where the generated code goes.
 std::ofstream output;
+/// @brief The root node of the program.
+auto program = std::unique_ptr<AstNode>{};
 
 extern void yylex_destroy();
 
@@ -14,7 +19,20 @@ int main(int argc, char** argv) {
   int ret = parser.parse();
 
   yylex_destroy();
+
+  // 1 if parsing failed because of invalid input;
+  // 2 if parsing failed due to memory exhaustion.
+  if (ret) {
+    return ret;
+  }
+
+  // perform analyses and transformations on the ast
+  auto scopes = ScopeStack{};
+  program->CheckType(scopes);
+  program->Dump(0);
+  program->CodeGen();
+
   output.close();
 
-  return ret;
+  return 0;
 }

--- a/parser.y
+++ b/parser.y
@@ -1,6 +1,5 @@
 %{
 
-#include <fstream>
 #include <iostream>
 #include <memory>
 #include <utility>
@@ -10,7 +9,6 @@
 #include "lex.yy.c"
 #include "type.hpp"
 
-extern std::ofstream output;
 extern std::unique_ptr<AstNode> program;
 %}
 

--- a/parser.y
+++ b/parser.y
@@ -2,13 +2,15 @@
 
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <utility>
 
+#include "ast.hpp"
 #include "lex.yy.c"
-#include "scope.hpp"
 #include "type.hpp"
 
 extern std::ofstream output;
+extern std::unique_ptr<AstNode> program;
 %}
 
 // Dependency code required for the value and location types;
@@ -61,11 +63,7 @@ extern std::ofstream output;
 
 %%
 entry: main_func {
-    auto program = std::make_unique<ProgramNode>($1);
-    auto scopes = ScopeStack{};
-    program->CheckType(scopes);
-    program->Dump(0);
-    program->CodeGen();
+    program = std::make_unique<ProgramNode>($1);
   }
   ;
 

--- a/parser.y
+++ b/parser.y
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "ast.hpp"
 #include "lex.yy.c"


### PR DESCRIPTION
This adjustment ensures that the parser can stay focused on its primary responsibilities. Additionally, it helps minimize the potential for parsing failures, as errors related to analyses and transformations are separated from parsing errors.