### PR TITLE
Read command line arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/setup-python@v3
       - name: Install QBE
         run: scripts/install-qbe.sh
+      - name: Install cxxopts
+        run: scripts/install-cxxopts.sh
       - name: Install Turnt
         run: pip install turnt
       - name: Run tests

--- a/main.cpp
+++ b/main.cpp
@@ -20,6 +20,7 @@ int main(int argc, char** argv) {
   // clang-format off
   cmd_options.add_options()
       ("o, output", "Write output to <file>", cxxopts::value<std::string>()->default_value("test.ssa"), "<file>")
+      ("d, dump", "Dump the abstract syntax tree", cxxopts::value<bool>()->default_value("false"))
       ("h, help", "Display available options")
       ;
   // clang-format on
@@ -44,7 +45,9 @@ int main(int argc, char** argv) {
   // perform analyses and transformations on the ast
   auto scopes = ScopeStack{};
   program->CheckType(scopes);
-  program->Dump(0);
+  if (args["dump"].as<bool>()) {
+    program->Dump(0);
+  }
   program->CodeGen();
 
   output.close();

--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,7 @@
+#include <cstdlib>
+#include <cxxopts.hpp>
 #include <fstream>
+#include <iostream>
 #include <memory>
 
 #include "ast.hpp"
@@ -13,8 +16,21 @@ auto program = std::unique_ptr<AstNode>{};
 extern void yylex_destroy();
 
 int main(int argc, char** argv) {
-  /* TODO: read input parameter */
-  output.open("test.ssa");
+  auto cmd_options = cxxopts::Options{argv[0], "A simple C compiler."};
+  // clang-format off
+  cmd_options.add_options()
+      ("o, output", "Write output to <file>", cxxopts::value<std::string>()->default_value("test.ssa"), "<file>")
+      ("h, help", "Display available options")
+      ;
+  // clang-format on
+
+  auto args = cmd_options.parse(argc, argv);
+  if (args.count("help")) {
+    std::cerr << cmd_options.help() << std::endl;
+    std::exit(0);
+  }
+
+  output.open(args["output"].as<std::string>());
   yy::parser parser{};
   int ret = parser.parse();
 

--- a/scripts/install-cxxopts.sh
+++ b/scripts/install-cxxopts.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+wget https://github.com/jarro2783/cxxopts/archive/refs/tags/v3.1.1.tar.gz -O - | tar zxf - &&
+  cd cxxopts-3.1.1/ &&
+  mkdir build/ &&
+  cmake -B build/ . &&
+  sudo make -C build/ install

--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -1,2 +1,2 @@
-command = "../vitaminc < {filename}"
+command = "../vitaminc --dump < {filename}"
 output.exp = "-"


### PR DESCRIPTION
This PR introduces a third party library, _cxxopts_, to effectively manage command line arguments.
Notably, this update enables the specification of an output file via the command line, and additionally offers the option to enable the dumping of the abstract syntax tree.