### PR TITLE
Fix check format script to recognize source files

### DIFF
--- a/scripts/check-format.sh
+++ b/scripts/check-format.sh
@@ -7,8 +7,12 @@
 
 SOURCES=$(find "$(git rev-parse --show-toplevel)" | grep -E "\.(c|h)pp\$")
 
-# reports violations
-clang-format --dry-run "${SOURCES}"
-
-VIOLATION_COUNT="$(clang-format --output-replacements-xml "${SOURCES}" | grep -E -c "</replacement>")"
-exit "$VIOLATION_COUNT"
+total_violation_count=0
+for file in $SOURCES; do
+  # reports violations
+  clang-format --dry-run "$file"
+  # count violations
+  violation_count=$(clang-format --output-replacements-xml "$file" | grep -E -c "</replacement>")
+  total_violation_count=$((total_violation_count + violation_count))
+done
+exit "$total_violation_count"


### PR DESCRIPTION
Previously, all source files were passed to clang-format as a SINGLE file,
resulting in _clang-format_ reporting an error due to "no such file or directory."

> **Note** 
> Another possible approach to resolve this issue is to remove the quotes around the variable, allowing word splitting. However, this may trigger a warning from [ShellCheck](https://github.com/koalaman/shellcheck) (SC2086: Double quote to prevent globbing and word splitting).
Also, it is generally recommended to [quote variables almost always](https://unix.stackexchange.com/questions/171346/security-implications-of-forgetting-to-quote-a-variable-in-bash-posix-shells) for safety.