### PR TITLE
Enhance error message verbosity

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -38,6 +38,12 @@ extern std::unique_ptr<AstNode> program;
 %define api.value.automove
 // This guarantees that headers do not conflict when included together.
 %define api.token.prefix {TOK_}
+// Have messages report the unexpected token, and possibly the expected ones.
+// Without this, the error message is always only "syntax error".
+%define parse.error verbose
+// Improve syntax error handling, as LALR parser might perform additional
+// parser stack reductions before discovering the syntax error.
+%define parse.lac full
 
 %token <int> NUM
 %token <std::string> ID


### PR DESCRIPTION
## What's the Problem?

To reproduce the issue, first, create a test file under the project root using the following command:

```sh
touch test.c
cat << EOF > test.c
int main() {
  return -1 * 2;
}
EOF
```

Next, compile the test file with VitaminC.
As of now, we don't yet support unary `-`, resulting in the "syntax error" message:

```sh
./vitaminc < test.c
# syntax error
```
As you can see, this error message lacks detail and doesn't provide insights into the actual error.

This pull request introduces an improvement by enhancing the error message verbosity:

```sh
./vitaminc < test.c
# syntax error, unexpected '-', expecting NUM or ID or '('
```

With this change, the error message is now more informative and helps in diagnosing the issue.
