### PR TITLE
Check type with the Visitor pattern

### DIFF
--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -56,7 +56,6 @@ class DeclNode : public AstNode {
 
   void CheckType(ScopeStack& env) override;
 
- protected:
   std::string id_;
   ExprType type_;
   std::unique_ptr<ExprNode> init_;
@@ -78,7 +77,6 @@ class BlockStmtNode : public StmtNode {
 
   void CheckType(ScopeStack& env) override;
 
- protected:
   std::vector<std::unique_ptr<DeclNode>> decls_;
   std::vector<std::unique_ptr<StmtNode>> stmts_;
 };
@@ -99,7 +97,6 @@ class ProgramNode : public AstNode {
 
   void CheckType(ScopeStack& env) override;
 
- protected:
   std::unique_ptr<BlockStmtNode> block_;
 };
 
@@ -128,7 +125,6 @@ class ReturnStmtNode : public StmtNode {
 
   void CheckType(ScopeStack& env) override;
 
- protected:
   std::unique_ptr<ExprNode> expr_;
 };
 
@@ -147,7 +143,6 @@ class ExprStmtNode : public StmtNode {
 
   void CheckType(ScopeStack& env) override;
 
- protected:
   std::unique_ptr<ExprNode> expr_;
 };
 
@@ -164,7 +159,6 @@ class IdExprNode : public ExprNode {
 
   void CheckType(ScopeStack& env) override;
 
- protected:
   std::string id_;
 };
 
@@ -181,7 +175,6 @@ class IntConstExprNode : public ExprNode {
 
   void CheckType(ScopeStack& env) override;
 
- protected:
   int val_;
 };
 
@@ -200,7 +193,6 @@ class BinaryExprNode : public ExprNode {
 
   void CheckType(ScopeStack& env) override;
 
- protected:
   std::unique_ptr<ExprNode> lhs_;
   std::unique_ptr<ExprNode> rhs_;
 
@@ -217,7 +209,6 @@ class PlusExprNode : public BinaryExprNode {
   virtual void Accept(Visitor<false>&) const;
   virtual void Accept(Visitor<true>&);
 
- protected:
   std::string OpName_() const override;
 
   std::string Op_() const override;
@@ -230,7 +221,6 @@ class SubExprNode : public BinaryExprNode {
   virtual void Accept(Visitor<false>&) const;
   virtual void Accept(Visitor<true>&);
 
- protected:
   std::string OpName_() const override;
 
   std::string Op_() const override;
@@ -243,7 +233,6 @@ class MulExprNode : public BinaryExprNode {
   virtual void Accept(Visitor<false>&) const;
   virtual void Accept(Visitor<true>&);
 
- protected:
   std::string OpName_() const override;
 
   std::string Op_() const override;
@@ -256,7 +245,6 @@ class DivExprNode : public BinaryExprNode {
   virtual void Accept(Visitor<false>&) const;
   virtual void Accept(Visitor<true>&);
 
- protected:
   std::string OpName_() const override;
 
   std::string Op_() const override;
@@ -269,7 +257,6 @@ class ModExprNode : public BinaryExprNode {
   virtual void Accept(Visitor<false>&) const;
   virtual void Accept(Visitor<true>&);
 
- protected:
   std::string OpName_() const override;
 
   std::string Op_() const override;
@@ -282,7 +269,6 @@ class GreaterThanExprNode : public BinaryExprNode {
   virtual void Accept(Visitor<false>&) const;
   virtual void Accept(Visitor<true>&);
 
- protected:
   std::string OpName_() const override;
 
   std::string Op_() const override;
@@ -295,7 +281,6 @@ class GreaterThanOrEqualToExprNode : public BinaryExprNode {
   virtual void Accept(Visitor<false>&) const;
   virtual void Accept(Visitor<true>&);
 
- protected:
   std::string OpName_() const override;
 
   std::string Op_() const override;
@@ -308,7 +293,6 @@ class LessThanExprNode : public BinaryExprNode {
   virtual void Accept(Visitor<false>&) const;
   virtual void Accept(Visitor<true>&);
 
- protected:
   std::string OpName_() const override;
 
   std::string Op_() const override;
@@ -321,7 +305,6 @@ class LessThanOrEqualToExprNode : public BinaryExprNode {
   virtual void Accept(Visitor<false>&) const;
   virtual void Accept(Visitor<true>&);
 
- protected:
   std::string OpName_() const override;
 
   std::string Op_() const override;
@@ -334,7 +317,6 @@ class EqualToExprNode : public BinaryExprNode {
   virtual void Accept(Visitor<false>&) const;
   virtual void Accept(Visitor<true>&);
 
- protected:
   std::string OpName_() const override;
 
   std::string Op_() const override;
@@ -347,7 +329,6 @@ class NotEqualToExprNode : public BinaryExprNode {
   virtual void Accept(Visitor<false>&) const;
   virtual void Accept(Visitor<true>&);
 
- protected:
   std::string OpName_() const override;
 
   std::string Op_() const override;
@@ -374,7 +355,6 @@ class SimpleAssignmentExprNode : public AssignmentExprNode {
 
   void CheckType(ScopeStack& env) override;
 
- protected:
   std::string id_;
   std::unique_ptr<ExprNode> expr_;
 };

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -8,16 +8,14 @@
 
 #include "scope.hpp"
 #include "type.hpp"
-
-template <bool>
-class Visitor;
+#include "visitor.hpp"
 
 /// @brief The most general base node of the Abstract Syntax Tree.
 /// @note This is an abstract class.
 class AstNode {
  public:
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   virtual int CodeGen() const = 0;
   /// @param pad The length of the padding.
@@ -29,16 +27,16 @@ class AstNode {
 
 /// @note This is an abstract class.
 class StmtNode : public AstNode {
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 };
 
 /// @note This is an abstract class.
 class ExprNode : public AstNode {
  public:
   ExprType type = ExprType::kUnknown;
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 };
 
 class DeclNode : public AstNode {
@@ -47,8 +45,8 @@ class DeclNode : public AstNode {
            std::unique_ptr<ExprNode> init = {})
       : id_{id}, type_{decl_type}, init_{std::move(init)} {}
 
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   int CodeGen() const override;
 
@@ -68,8 +66,8 @@ class BlockStmtNode : public StmtNode {
                 std::vector<std::unique_ptr<StmtNode>>&& stmts)
       : decls_{std::move(decls)}, stmts_{std::move(stmts)} {}
 
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   int CodeGen() const override;
 
@@ -88,8 +86,8 @@ class ProgramNode : public AstNode {
   ProgramNode(std::unique_ptr<BlockStmtNode> block)
       : block_{std::move(block)} {}
 
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   int CodeGen() const override;
 
@@ -102,8 +100,8 @@ class ProgramNode : public AstNode {
 
 class NullStmtNode : public StmtNode {
  public:
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   int CodeGen() const override;
 
@@ -116,8 +114,8 @@ class ReturnStmtNode : public StmtNode {
  public:
   ReturnStmtNode(std::unique_ptr<ExprNode> expr) : expr_{std::move(expr)} {}
 
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   int CodeGen() const override;
 
@@ -134,8 +132,8 @@ class ExprStmtNode : public StmtNode {
  public:
   ExprStmtNode(std::unique_ptr<ExprNode> expr) : expr_{std::move(expr)} {}
 
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   int CodeGen() const override;
 
@@ -150,8 +148,8 @@ class IdExprNode : public ExprNode {
  public:
   IdExprNode(const std::string& id) : id_{id} {}
 
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   int CodeGen() const override;
 
@@ -166,8 +164,8 @@ class IntConstExprNode : public ExprNode {
  public:
   IntConstExprNode(int val) : val_{val} {}
 
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   int CodeGen() const override;
 
@@ -184,8 +182,8 @@ class BinaryExprNode : public ExprNode {
   BinaryExprNode(std::unique_ptr<ExprNode> lhs, std::unique_ptr<ExprNode> rhs)
       : lhs_{std::move(lhs)}, rhs_{std::move(rhs)} {}
 
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   int CodeGen() const override;
 
@@ -206,8 +204,8 @@ class PlusExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   std::string OpName_() const override;
 
@@ -218,8 +216,8 @@ class SubExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   std::string OpName_() const override;
 
@@ -230,8 +228,8 @@ class MulExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   std::string OpName_() const override;
 
@@ -242,8 +240,8 @@ class DivExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   std::string OpName_() const override;
 
@@ -254,8 +252,8 @@ class ModExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   std::string OpName_() const override;
 
@@ -266,8 +264,8 @@ class GreaterThanExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   std::string OpName_() const override;
 
@@ -278,8 +276,8 @@ class GreaterThanOrEqualToExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   std::string OpName_() const override;
 
@@ -290,8 +288,8 @@ class LessThanExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   std::string OpName_() const override;
 
@@ -302,8 +300,8 @@ class LessThanOrEqualToExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   std::string OpName_() const override;
 
@@ -314,8 +312,8 @@ class EqualToExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   std::string OpName_() const override;
 
@@ -326,8 +324,8 @@ class NotEqualToExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   std::string OpName_() const override;
 
@@ -337,8 +335,8 @@ class NotEqualToExprNode : public BinaryExprNode {
 /// @note This is an abstract class.
 class AssignmentExprNode : public ExprNode {
  public:
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 };
 
 class SimpleAssignmentExprNode : public AssignmentExprNode {
@@ -346,8 +344,8 @@ class SimpleAssignmentExprNode : public AssignmentExprNode {
   SimpleAssignmentExprNode(std::string id, std::unique_ptr<ExprNode> expr)
       : id_{std::move(id)}, expr_{std::move(expr)} {}
 
-  virtual void Accept(Visitor<false>&) const;
-  virtual void Accept(Visitor<true>&);
+  virtual void Accept(NonModifyingVisitor&) const;
+  virtual void Accept(ModifyingVisitor&);
 
   int CodeGen() const override;
 

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -9,10 +9,16 @@
 #include "scope.hpp"
 #include "type.hpp"
 
+template <bool>
+class Visitor;
+
 /// @brief The most general base node of the Abstract Syntax Tree.
 /// @note This is an abstract class.
 class AstNode {
  public:
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
+
   virtual int CodeGen() const = 0;
   /// @param pad The length of the padding.
   virtual void Dump(int pad) const = 0;
@@ -22,12 +28,17 @@ class AstNode {
 };
 
 /// @note This is an abstract class.
-class StmtNode : public AstNode {};
+class StmtNode : public AstNode {
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
+};
 
 /// @note This is an abstract class.
 class ExprNode : public AstNode {
  public:
   ExprType type = ExprType::kUnknown;
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
 };
 
 class DeclNode : public AstNode {
@@ -35,6 +46,9 @@ class DeclNode : public AstNode {
   DeclNode(const std::string& id, ExprType decl_type,
            std::unique_ptr<ExprNode> init = {})
       : id_{id}, type_{decl_type}, init_{std::move(init)} {}
+
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
 
   int CodeGen() const override;
 
@@ -55,6 +69,9 @@ class BlockStmtNode : public StmtNode {
                 std::vector<std::unique_ptr<StmtNode>>&& stmts)
       : decls_{std::move(decls)}, stmts_{std::move(stmts)} {}
 
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
+
   int CodeGen() const override;
 
   void Dump(int pad) const override;
@@ -73,6 +90,9 @@ class ProgramNode : public AstNode {
   ProgramNode(std::unique_ptr<BlockStmtNode> block)
       : block_{std::move(block)} {}
 
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
+
   int CodeGen() const override;
 
   void Dump(int pad) const override;
@@ -85,6 +105,9 @@ class ProgramNode : public AstNode {
 
 class NullStmtNode : public StmtNode {
  public:
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
+
   int CodeGen() const override;
 
   void Dump(int pad) const override;
@@ -95,6 +118,9 @@ class NullStmtNode : public StmtNode {
 class ReturnStmtNode : public StmtNode {
  public:
   ReturnStmtNode(std::unique_ptr<ExprNode> expr) : expr_{std::move(expr)} {}
+
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
 
   int CodeGen() const override;
 
@@ -112,6 +138,9 @@ class ExprStmtNode : public StmtNode {
  public:
   ExprStmtNode(std::unique_ptr<ExprNode> expr) : expr_{std::move(expr)} {}
 
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
+
   int CodeGen() const override;
 
   void Dump(int pad) const override;
@@ -126,6 +155,9 @@ class IdExprNode : public ExprNode {
  public:
   IdExprNode(const std::string& id) : id_{id} {}
 
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
+
   int CodeGen() const override;
 
   void Dump(int pad) const override;
@@ -139,6 +171,9 @@ class IdExprNode : public ExprNode {
 class IntConstExprNode : public ExprNode {
  public:
   IntConstExprNode(int val) : val_{val} {}
+
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
 
   int CodeGen() const override;
 
@@ -155,6 +190,9 @@ class BinaryExprNode : public ExprNode {
  public:
   BinaryExprNode(std::unique_ptr<ExprNode> lhs, std::unique_ptr<ExprNode> rhs)
       : lhs_{std::move(lhs)}, rhs_{std::move(rhs)} {}
+
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
 
   int CodeGen() const override;
 
@@ -175,6 +213,10 @@ class BinaryExprNode : public ExprNode {
 class PlusExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
+ public:
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
+
  protected:
   std::string OpName_() const override;
 
@@ -183,6 +225,10 @@ class PlusExprNode : public BinaryExprNode {
 
 class SubExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
+
+ public:
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
 
  protected:
   std::string OpName_() const override;
@@ -193,6 +239,10 @@ class SubExprNode : public BinaryExprNode {
 class MulExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
+ public:
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
+
  protected:
   std::string OpName_() const override;
 
@@ -201,6 +251,10 @@ class MulExprNode : public BinaryExprNode {
 
 class DivExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
+
+ public:
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
 
  protected:
   std::string OpName_() const override;
@@ -211,6 +265,10 @@ class DivExprNode : public BinaryExprNode {
 class ModExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
+ public:
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
+
  protected:
   std::string OpName_() const override;
 
@@ -219,6 +277,10 @@ class ModExprNode : public BinaryExprNode {
 
 class GreaterThanExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
+
+ public:
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
 
  protected:
   std::string OpName_() const override;
@@ -229,6 +291,10 @@ class GreaterThanExprNode : public BinaryExprNode {
 class GreaterThanOrEqualToExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
+ public:
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
+
  protected:
   std::string OpName_() const override;
 
@@ -237,6 +303,10 @@ class GreaterThanOrEqualToExprNode : public BinaryExprNode {
 
 class LessThanExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
+
+ public:
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
 
  protected:
   std::string OpName_() const override;
@@ -247,6 +317,10 @@ class LessThanExprNode : public BinaryExprNode {
 class LessThanOrEqualToExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
+ public:
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
+
  protected:
   std::string OpName_() const override;
 
@@ -255,6 +329,10 @@ class LessThanOrEqualToExprNode : public BinaryExprNode {
 
 class EqualToExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
+
+ public:
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
 
  protected:
   std::string OpName_() const override;
@@ -265,6 +343,10 @@ class EqualToExprNode : public BinaryExprNode {
 class NotEqualToExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
+ public:
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
+
  protected:
   std::string OpName_() const override;
 
@@ -272,12 +354,19 @@ class NotEqualToExprNode : public BinaryExprNode {
 };
 
 /// @note This is an abstract class.
-class AssignmentExprNode : public ExprNode {};
+class AssignmentExprNode : public ExprNode {
+ public:
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
+};
 
 class SimpleAssignmentExprNode : public AssignmentExprNode {
  public:
   SimpleAssignmentExprNode(std::string id, std::unique_ptr<ExprNode> expr)
       : id_{std::move(id)}, expr_{std::move(expr)} {}
+
+  virtual void Accept(Visitor<false>&) const;
+  virtual void Accept(Visitor<true>&);
 
   int CodeGen() const override;
 

--- a/include/type_checker.hpp
+++ b/include/type_checker.hpp
@@ -5,7 +5,7 @@
 #include "visitor.hpp"
 
 /// @brief A modifying pass; resolves the type of expressions.
-class TypeChecker : public Visitor<true> {
+class TypeChecker : public ModifyingVisitor {
  public:
   TypeChecker(ScopeStack& env) : env_{env} {}
 

--- a/include/type_checker.hpp
+++ b/include/type_checker.hpp
@@ -1,0 +1,27 @@
+#ifndef TYPE_CHECKER_HPP_
+#define TYPE_CHECKER_HPP_
+
+#include "scope.hpp"
+#include "visitor.hpp"
+
+/// @brief A modifying pass; resolves the type of expressions.
+class TypeChecker : public Visitor<true> {
+ public:
+  TypeChecker(ScopeStack& env) : env_{env} {}
+
+  void Visit(DeclNode&) override;
+  void Visit(BlockStmtNode&) override;
+  void Visit(ProgramNode&) override;
+  void Visit(NullStmtNode&) override;
+  void Visit(ReturnStmtNode&) override;
+  void Visit(ExprStmtNode&) override;
+  void Visit(IdExprNode&) override;
+  void Visit(IntConstExprNode&) override;
+  void Visit(BinaryExprNode&) override;
+  void Visit(SimpleAssignmentExprNode&) override;
+
+ private:
+  ScopeStack& env_;
+};
+
+#endif  // TYPE_CHECKER_HPP_

--- a/include/visitor.hpp
+++ b/include/visitor.hpp
@@ -34,6 +34,7 @@ class SimpleAssignmentExprNode;
 
 /// @tparam is_modifying If `true`, `Visit()` takes a non-const reference of the
 /// visitable; otherwise, a const reference. Default to `false`.
+/// @note This is an abstract class.
 /// @note For concrete Visitors, define `Visit()` on the classes that you care
 /// about, others will do nothing by default.
 template <bool is_modifying = false>
@@ -73,8 +74,13 @@ class Visitor {
   virtual void Visit(CondMut<AssignmentExprNode>&){};
   virtual void Visit(CondMut<SimpleAssignmentExprNode>&){};
 
-  virtual ~Visitor() = default;
+  /// @note To make the class abstract. But still we have to provide an
+  /// out-of-class definition for the destructor.
+  virtual ~Visitor() = 0;
 };
+
+template <bool is_modifying>
+Visitor<is_modifying>::~Visitor() = default;
 
 // One can use these type aliases in cases where the meaning of the template
 // parameter is not obvious.

--- a/include/visitor.hpp
+++ b/include/visitor.hpp
@@ -1,0 +1,79 @@
+#ifndef VISITOR_HPP_
+#define VISITOR_HPP_
+
+#include <type_traits>
+
+// Forward declarations to fix the acyclic problem with name only dependency.
+// NOTE: update the list every time a new kind of node is introduced.
+
+class AstNode;
+class StmtNode;
+class ExprNode;
+class DeclNode;
+class BlockStmtNode;
+class ProgramNode;
+class NullStmtNode;
+class ReturnStmtNode;
+class ExprStmtNode;
+class IdExprNode;
+class IntConstExprNode;
+class BinaryExprNode;
+class PlusExprNode;
+class SubExprNode;
+class MulExprNode;
+class DivExprNode;
+class ModExprNode;
+class GreaterThanExprNode;
+class GreaterThanOrEqualToExprNode;
+class LessThanExprNode;
+class LessThanOrEqualToExprNode;
+class EqualToExprNode;
+class NotEqualToExprNode;
+class AssignmentExprNode;
+class SimpleAssignmentExprNode;
+
+/// @tparam is_modifying If `true`, `Visit()` takes a non-const reference of the
+/// visitable; otherwise, a const reference. Default to `false`.
+/// @note For concrete Visitors, define `Visit()` on the classes that you care
+/// about, others will do nothing by default.
+template <bool is_modifying = false>
+class Visitor {
+ public:
+  /// @brief Conditionally mutable.
+  template <typename Visitable>
+  using CondMut = std::conditional_t<is_modifying, Visitable, const Visitable>;
+
+  // Notice that the `Visit()` function is also defined for abstract classes.
+  // This is to provide the fallback operation for all concrete classes derived
+  // from such abstract class.
+
+  virtual void Visit(CondMut<AstNode>&){};
+  virtual void Visit(CondMut<StmtNode>&){};
+  virtual void Visit(CondMut<ExprNode>&){};
+  virtual void Visit(CondMut<DeclNode>&){};
+  virtual void Visit(CondMut<BlockStmtNode>&){};
+  virtual void Visit(CondMut<ProgramNode>&){};
+  virtual void Visit(CondMut<NullStmtNode>&){};
+  virtual void Visit(CondMut<ReturnStmtNode>&){};
+  virtual void Visit(CondMut<ExprStmtNode>&){};
+  virtual void Visit(CondMut<IdExprNode>&){};
+  virtual void Visit(CondMut<IntConstExprNode>&){};
+  virtual void Visit(CondMut<BinaryExprNode>&){};
+  virtual void Visit(CondMut<PlusExprNode>&){};
+  virtual void Visit(CondMut<SubExprNode>&){};
+  virtual void Visit(CondMut<MulExprNode>&){};
+  virtual void Visit(CondMut<DivExprNode>&){};
+  virtual void Visit(CondMut<ModExprNode>&){};
+  virtual void Visit(CondMut<GreaterThanExprNode>&){};
+  virtual void Visit(CondMut<GreaterThanOrEqualToExprNode>&){};
+  virtual void Visit(CondMut<LessThanExprNode>&){};
+  virtual void Visit(CondMut<LessThanOrEqualToExprNode>&){};
+  virtual void Visit(CondMut<EqualToExprNode>&){};
+  virtual void Visit(CondMut<NotEqualToExprNode>&){};
+  virtual void Visit(CondMut<AssignmentExprNode>&){};
+  virtual void Visit(CondMut<SimpleAssignmentExprNode>&){};
+
+  virtual ~Visitor() = default;
+};
+
+#endif  // VISITOR_HPP_

--- a/include/visitor.hpp
+++ b/include/visitor.hpp
@@ -76,4 +76,10 @@ class Visitor {
   virtual ~Visitor() = default;
 };
 
+// One can use these type aliases in cases where the meaning of the template
+// parameter is not obvious.
+
+using ModifyingVisitor = Visitor<true>;
+using NonModifyingVisitor = Visitor<false>;
+
 #endif  // VISITOR_HPP_

--- a/main.cpp
+++ b/main.cpp
@@ -6,6 +6,7 @@
 
 #include "ast.hpp"
 #include "scope.hpp"
+#include "type_checker.hpp"
 #include "y.tab.h"
 
 /// @brief Where the generated code goes.
@@ -44,7 +45,8 @@ int main(int argc, char** argv) {
 
   // perform analyses and transformations on the ast
   auto scopes = ScopeStack{};
-  program->CheckType(scopes);
+  auto type_checker = TypeChecker{scopes};
+  program->Accept(type_checker);
   if (args["dump"].as<bool>()) {
     program->Dump(0);
   }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -11,6 +11,7 @@
 #include "scope.hpp"
 #include "symbol.hpp"
 #include "type.hpp"
+#include "visitor.hpp"
 
 /// @brief qbe intermediate file
 extern std::ofstream output;
@@ -49,6 +50,38 @@ std::string PrefixSigil(int local_num) {
 std::map<std::string, int> id_to_num{};
 
 }  // namespace
+
+void AstNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void AstNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
+}
+
+void StmtNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void StmtNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
+}
+
+void ExprNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void ExprNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
+}
+
+void DeclNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void DeclNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
+}
 
 int DeclNode::CodeGen() const {
   int id_num = NextLocalNum();
@@ -91,6 +124,14 @@ void DeclNode::CheckType(ScopeStack& env) {
   }
 }
 
+void BlockStmtNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void BlockStmtNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
+}
+
 int BlockStmtNode::CodeGen() const {
   output << "@start" << std::endl;
   for (const auto& decl : decls_) {
@@ -123,7 +164,13 @@ void BlockStmtNode::CheckType(ScopeStack& env) {
   env.PopScope();
 }
 
-/// @brief Root of the entire program.
+void ProgramNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void ProgramNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
+}
 
 int ProgramNode::CodeGen() const {
   output << "export function w $main() {" << std::endl;
@@ -141,6 +188,14 @@ void ProgramNode::CheckType(ScopeStack& env) {
   block_->CheckType(env);
 }
 
+void NullStmtNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void NullStmtNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
+}
+
 int NullStmtNode::CodeGen() const {
   return kDummyLocalNum;
 }
@@ -150,6 +205,14 @@ void NullStmtNode::Dump(int pad) const {
 }
 
 void NullStmtNode::CheckType(ScopeStack& env) {}
+
+void ReturnStmtNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void ReturnStmtNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
+}
 
 int ReturnStmtNode::CodeGen() const {
   int ret_num = expr_->CodeGen();
@@ -170,6 +233,14 @@ void ReturnStmtNode::CheckType(ScopeStack& env) {
   }
 }
 
+void ExprStmtNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void ExprStmtNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
+}
+
 int ExprStmtNode::CodeGen() const {
   expr_->CodeGen();
 
@@ -182,6 +253,14 @@ void ExprStmtNode::Dump(int pad) const {
 
 void ExprStmtNode::CheckType(ScopeStack& env) {
   expr_->CheckType(env);
+}
+
+void IdExprNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void IdExprNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
 }
 
 int IdExprNode::CodeGen() const {
@@ -206,6 +285,14 @@ void IdExprNode::CheckType(ScopeStack& env) {
   }
 }
 
+void IntConstExprNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void IntConstExprNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
+}
+
 int IntConstExprNode::CodeGen() const {
   int num = NextLocalNum();
   output << PrefixSigil(num) << " =w copy " << val_ << std::endl;
@@ -218,6 +305,14 @@ void IntConstExprNode::Dump(int pad) const {
 
 void IntConstExprNode::CheckType(ScopeStack& env) {
   type = ExprType::kInt;
+}
+
+void BinaryExprNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void BinaryExprNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
 }
 
 int BinaryExprNode::CodeGen() const {
@@ -248,12 +343,28 @@ void BinaryExprNode::CheckType(ScopeStack& env) {
   }
 }
 
+void PlusExprNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void PlusExprNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
+}
+
 std::string PlusExprNode::OpName_() const {
   return "add";
 }
 
 std::string PlusExprNode::Op_() const {
   return "+";
+}
+
+void SubExprNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void SubExprNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
 }
 
 std::string SubExprNode::OpName_() const {
@@ -264,12 +375,28 @@ std::string SubExprNode::Op_() const {
   return "-";
 }
 
+void MulExprNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void MulExprNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
+}
+
 std::string MulExprNode::OpName_() const {
   return "mul";
 }
 
 std::string MulExprNode::Op_() const {
   return "*";
+}
+
+void DivExprNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void DivExprNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
 }
 
 std::string DivExprNode::OpName_() const {
@@ -280,12 +407,28 @@ std::string DivExprNode::Op_() const {
   return "/";
 }
 
+void ModExprNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void ModExprNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
+}
+
 std::string ModExprNode::OpName_() const {
   return "rem";
 }
 
 std::string ModExprNode::Op_() const {
   return "%";
+}
+
+void GreaterThanExprNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void GreaterThanExprNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
 }
 
 std::string GreaterThanExprNode::OpName_() const {
@@ -297,6 +440,14 @@ std::string GreaterThanExprNode::Op_() const {
   return ">";
 }
 
+void GreaterThanOrEqualToExprNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void GreaterThanOrEqualToExprNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
+}
+
 std::string GreaterThanOrEqualToExprNode::OpName_() const {
   // signed
   return "sge";
@@ -304,6 +455,14 @@ std::string GreaterThanOrEqualToExprNode::OpName_() const {
 
 std::string GreaterThanOrEqualToExprNode::Op_() const {
   return ">=";
+}
+
+void LessThanExprNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void LessThanExprNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
 }
 
 std::string LessThanExprNode::OpName_() const {
@@ -315,6 +474,14 @@ std::string LessThanExprNode::Op_() const {
   return "<";
 }
 
+void LessThanOrEqualToExprNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void LessThanOrEqualToExprNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
+}
+
 std::string LessThanOrEqualToExprNode::OpName_() const {
   // signed
   return "sle";
@@ -322,6 +489,14 @@ std::string LessThanOrEqualToExprNode::OpName_() const {
 
 std::string LessThanOrEqualToExprNode::Op_() const {
   return "<=";
+}
+
+void EqualToExprNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void EqualToExprNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
 }
 
 std::string EqualToExprNode::OpName_() const {
@@ -332,12 +507,36 @@ std::string EqualToExprNode::Op_() const {
   return "==";
 }
 
+void NotEqualToExprNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void NotEqualToExprNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
+}
+
 std::string NotEqualToExprNode::OpName_() const {
   return "ne";
 }
 
 std::string NotEqualToExprNode::Op_() const {
   return "!=";
+}
+
+void AssignmentExprNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void AssignmentExprNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
+}
+
+void SimpleAssignmentExprNode::Accept(Visitor<false>& v) const {
+  v.Visit(*this);
+}
+
+void SimpleAssignmentExprNode::Accept(Visitor<true>& v) {
+  v.Visit(*this);
 }
 
 int SimpleAssignmentExprNode::CodeGen() const {

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -51,35 +51,35 @@ std::map<std::string, int> id_to_num{};
 
 }  // namespace
 
-void AstNode::Accept(Visitor<false>& v) const {
+void AstNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void AstNode::Accept(Visitor<true>& v) {
+void AstNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
-void StmtNode::Accept(Visitor<false>& v) const {
+void StmtNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void StmtNode::Accept(Visitor<true>& v) {
+void StmtNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
-void ExprNode::Accept(Visitor<false>& v) const {
+void ExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void ExprNode::Accept(Visitor<true>& v) {
+void ExprNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
-void DeclNode::Accept(Visitor<false>& v) const {
+void DeclNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void DeclNode::Accept(Visitor<true>& v) {
+void DeclNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
@@ -124,11 +124,11 @@ void DeclNode::CheckType(ScopeStack& env) {
   }
 }
 
-void BlockStmtNode::Accept(Visitor<false>& v) const {
+void BlockStmtNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void BlockStmtNode::Accept(Visitor<true>& v) {
+void BlockStmtNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
@@ -164,11 +164,11 @@ void BlockStmtNode::CheckType(ScopeStack& env) {
   env.PopScope();
 }
 
-void ProgramNode::Accept(Visitor<false>& v) const {
+void ProgramNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void ProgramNode::Accept(Visitor<true>& v) {
+void ProgramNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
@@ -188,11 +188,11 @@ void ProgramNode::CheckType(ScopeStack& env) {
   block_->CheckType(env);
 }
 
-void NullStmtNode::Accept(Visitor<false>& v) const {
+void NullStmtNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void NullStmtNode::Accept(Visitor<true>& v) {
+void NullStmtNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
@@ -206,11 +206,11 @@ void NullStmtNode::Dump(int pad) const {
 
 void NullStmtNode::CheckType(ScopeStack& env) {}
 
-void ReturnStmtNode::Accept(Visitor<false>& v) const {
+void ReturnStmtNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void ReturnStmtNode::Accept(Visitor<true>& v) {
+void ReturnStmtNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
@@ -233,11 +233,11 @@ void ReturnStmtNode::CheckType(ScopeStack& env) {
   }
 }
 
-void ExprStmtNode::Accept(Visitor<false>& v) const {
+void ExprStmtNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void ExprStmtNode::Accept(Visitor<true>& v) {
+void ExprStmtNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
@@ -255,11 +255,11 @@ void ExprStmtNode::CheckType(ScopeStack& env) {
   expr_->CheckType(env);
 }
 
-void IdExprNode::Accept(Visitor<false>& v) const {
+void IdExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void IdExprNode::Accept(Visitor<true>& v) {
+void IdExprNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
@@ -285,11 +285,11 @@ void IdExprNode::CheckType(ScopeStack& env) {
   }
 }
 
-void IntConstExprNode::Accept(Visitor<false>& v) const {
+void IntConstExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void IntConstExprNode::Accept(Visitor<true>& v) {
+void IntConstExprNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
@@ -307,11 +307,11 @@ void IntConstExprNode::CheckType(ScopeStack& env) {
   type = ExprType::kInt;
 }
 
-void BinaryExprNode::Accept(Visitor<false>& v) const {
+void BinaryExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void BinaryExprNode::Accept(Visitor<true>& v) {
+void BinaryExprNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
@@ -343,11 +343,11 @@ void BinaryExprNode::CheckType(ScopeStack& env) {
   }
 }
 
-void PlusExprNode::Accept(Visitor<false>& v) const {
+void PlusExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void PlusExprNode::Accept(Visitor<true>& v) {
+void PlusExprNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
@@ -359,11 +359,11 @@ std::string PlusExprNode::Op_() const {
   return "+";
 }
 
-void SubExprNode::Accept(Visitor<false>& v) const {
+void SubExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void SubExprNode::Accept(Visitor<true>& v) {
+void SubExprNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
@@ -375,11 +375,11 @@ std::string SubExprNode::Op_() const {
   return "-";
 }
 
-void MulExprNode::Accept(Visitor<false>& v) const {
+void MulExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void MulExprNode::Accept(Visitor<true>& v) {
+void MulExprNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
@@ -391,11 +391,11 @@ std::string MulExprNode::Op_() const {
   return "*";
 }
 
-void DivExprNode::Accept(Visitor<false>& v) const {
+void DivExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void DivExprNode::Accept(Visitor<true>& v) {
+void DivExprNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
@@ -407,11 +407,11 @@ std::string DivExprNode::Op_() const {
   return "/";
 }
 
-void ModExprNode::Accept(Visitor<false>& v) const {
+void ModExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void ModExprNode::Accept(Visitor<true>& v) {
+void ModExprNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
@@ -423,11 +423,11 @@ std::string ModExprNode::Op_() const {
   return "%";
 }
 
-void GreaterThanExprNode::Accept(Visitor<false>& v) const {
+void GreaterThanExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void GreaterThanExprNode::Accept(Visitor<true>& v) {
+void GreaterThanExprNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
@@ -440,11 +440,11 @@ std::string GreaterThanExprNode::Op_() const {
   return ">";
 }
 
-void GreaterThanOrEqualToExprNode::Accept(Visitor<false>& v) const {
+void GreaterThanOrEqualToExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void GreaterThanOrEqualToExprNode::Accept(Visitor<true>& v) {
+void GreaterThanOrEqualToExprNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
@@ -457,11 +457,11 @@ std::string GreaterThanOrEqualToExprNode::Op_() const {
   return ">=";
 }
 
-void LessThanExprNode::Accept(Visitor<false>& v) const {
+void LessThanExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void LessThanExprNode::Accept(Visitor<true>& v) {
+void LessThanExprNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
@@ -474,11 +474,11 @@ std::string LessThanExprNode::Op_() const {
   return "<";
 }
 
-void LessThanOrEqualToExprNode::Accept(Visitor<false>& v) const {
+void LessThanOrEqualToExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void LessThanOrEqualToExprNode::Accept(Visitor<true>& v) {
+void LessThanOrEqualToExprNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
@@ -491,11 +491,11 @@ std::string LessThanOrEqualToExprNode::Op_() const {
   return "<=";
 }
 
-void EqualToExprNode::Accept(Visitor<false>& v) const {
+void EqualToExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void EqualToExprNode::Accept(Visitor<true>& v) {
+void EqualToExprNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
@@ -507,11 +507,11 @@ std::string EqualToExprNode::Op_() const {
   return "==";
 }
 
-void NotEqualToExprNode::Accept(Visitor<false>& v) const {
+void NotEqualToExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void NotEqualToExprNode::Accept(Visitor<true>& v) {
+void NotEqualToExprNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
@@ -523,19 +523,19 @@ std::string NotEqualToExprNode::Op_() const {
   return "!=";
 }
 
-void AssignmentExprNode::Accept(Visitor<false>& v) const {
+void AssignmentExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void AssignmentExprNode::Accept(Visitor<true>& v) {
+void AssignmentExprNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
-void SimpleAssignmentExprNode::Accept(Visitor<false>& v) const {
+void SimpleAssignmentExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void SimpleAssignmentExprNode::Accept(Visitor<true>& v) {
+void SimpleAssignmentExprNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -1,0 +1,91 @@
+#include "type_checker.hpp"
+
+#include "ast.hpp"
+
+void TypeChecker::Visit(DeclNode& decl) {
+  if (decl.init_) {
+    decl.init_->CheckType(env_);
+    if (decl.init_->type != decl.type_) {
+      // TODO: incompatible types when initializing type 'type_' using type
+      // 'init_->type'
+    }
+  }
+
+  if (env_.Probe(decl.id_)) {
+    // TODO: redefinition of 'id_'
+  } else {
+    auto symbol = std::make_unique<SymbolEntry>(decl.id_);
+    symbol->expr_type = decl.type_;
+    env_.Add(std::move(symbol));
+  }
+}
+
+void TypeChecker::Visit(BlockStmtNode& block) {
+  env_.PushScope();
+  for (auto& decl : block.decls_) {
+    decl->CheckType(env_);
+  }
+  for (auto& stmt : block.stmts_) {
+    stmt->CheckType(env_);
+  }
+  env_.PopScope();
+}
+
+void TypeChecker::Visit(ProgramNode& program) {
+  program.block_->Accept(*this);
+}
+
+void TypeChecker::Visit(NullStmtNode&) {
+  /* do nothing */
+}
+
+void TypeChecker::Visit(ReturnStmtNode& ret_stmt) {
+  ret_stmt.expr_->CheckType(env_);
+  if (ret_stmt.expr_->type != ExprType::kInt) {
+    // TODO: return value type does not match the function type
+  }
+}
+
+void TypeChecker::Visit(ExprStmtNode& expr_stmt) {
+  expr_stmt.expr_->Accept(*this);
+}
+
+void TypeChecker::Visit(IdExprNode& id_expr) {
+  if (auto symbol = env_.LookUp(id_expr.id_)) {
+    id_expr.type = symbol->expr_type;
+  } else {
+    // TODO: 'id_' undeclared
+  }
+}
+
+void TypeChecker::Visit(IntConstExprNode& int_expr) {
+  int_expr.type = ExprType::kInt;
+}
+
+void TypeChecker::Visit(BinaryExprNode& bin_expr) {
+  bin_expr.lhs_->Accept(*this);
+  bin_expr.rhs_->Accept(*this);
+  if (bin_expr.lhs_->type != bin_expr.rhs_->type) {
+    // TODO: invalid operands to binary +
+  } else {
+    bin_expr.type = bin_expr.lhs_->type;
+  }
+}
+
+void TypeChecker::Visit(SimpleAssignmentExprNode& assign_expr) {
+  assign_expr.expr_->Accept(*this);
+  if (auto symbol = env_.LookUp(assign_expr.id_)) {
+    if (assign_expr.expr_->type == symbol->expr_type) {
+      // 6.5.16 Assignment operators
+      // The type of an assignment expression is the type of the left
+      // operand unless the left operand has qualified type, in which case it is
+      // the unqualified version of the type of the left operand.
+      assign_expr.type = symbol->expr_type;
+    } else {
+      // TODO: assigning to 'symbol->expr_type' from incompatible type
+      // 'expr_->type'
+    }
+  } else {
+    // TODO: 'id_' undeclared
+  }
+}


### PR DESCRIPTION
## How to Review

1. Take a look at `main.cpp` to see how the `TypeChecker` is being used.
2. In `src/type_checker.cpp`, you can find the logic for type checking. Compare the differences with the original `CheckType` functions that are located in each corresponding AST node. You should discover that Visitors may have state: the `ScopeStack` is no longer being passed as an argument.  
3. Examine `include/visitor.hpp` and read the comments. You should discover that each AST node has a corresponding `Visit()` function, and there are two kinds of Visitors based on the constancy of the AST node being passed.
4. Finally, review `include/ast.hpp`. Each AST node has two `Accept()` functions to accept the corresponding kind of Visitor, and their implementations in `src/ast.cpp` are all identical and straightforward. You may want to refer to the concept of [Visitor and Double Dispatch](https://refactoring.guru/design-patterns/visitor-double-dispatch) to understand why we need these `Accept()` functions.

> **Note**
> 1. All AST nodes are now made public without removing the suffix from the names of those being affected. Additionally, the old `CheckType` functions are retained intentionally. Both of these decisions are deliberate, as changing them would necessitate numerous minor modifications, which would complicate the reviewing process. Keeping the old functions allows reviewers to compare the differences.
> 2. I prefer to treat AST nodes as data classes and centralize operations within visitors. In this context, exposing data members publicly is a reasonable choice. However, it's worth noting that in C++, constant-ness doesn't propagate down to pointers, which can affect the true constancy of objects. We may revisit the design implications of this decision in the future.

## Further Work

- Remove the suffix from public data members and member functions.
- Remove `CheckType()` functions.
