### PR TITLE
Fix type checker calling deprecated type check

### DIFF
--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -27,6 +27,7 @@ class AstNode {
 
 /// @note This is an abstract class.
 class StmtNode : public AstNode {
+ public:
   virtual void Accept(NonModifyingVisitor&) const;
   virtual void Accept(ModifyingVisitor&);
 };

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -6,7 +6,6 @@
 #include <utility>
 #include <vector>
 
-#include "scope.hpp"
 #include "type.hpp"
 #include "visitor.hpp"
 
@@ -20,8 +19,6 @@ class AstNode {
   virtual int CodeGen() const = 0;
   /// @param pad The length of the padding.
   virtual void Dump(int pad) const = 0;
-  /// @brief A modifying pass; resolves the type of expressions.
-  virtual void CheckType(ScopeStack&) = 0;
   virtual ~AstNode() = default;
 };
 
@@ -53,8 +50,6 @@ class DeclNode : public AstNode {
 
   void Dump(int pad) const override;
 
-  void CheckType(ScopeStack& env) override;
-
   std::string id_;
   ExprType type_;
   std::unique_ptr<ExprNode> init_;
@@ -74,8 +69,6 @@ class BlockStmtNode : public StmtNode {
 
   void Dump(int pad) const override;
 
-  void CheckType(ScopeStack& env) override;
-
   std::vector<std::unique_ptr<DeclNode>> decls_;
   std::vector<std::unique_ptr<StmtNode>> stmts_;
 };
@@ -94,8 +87,6 @@ class ProgramNode : public AstNode {
 
   void Dump(int pad) const override;
 
-  void CheckType(ScopeStack& env) override;
-
   std::unique_ptr<BlockStmtNode> block_;
 };
 
@@ -107,8 +98,6 @@ class NullStmtNode : public StmtNode {
   int CodeGen() const override;
 
   void Dump(int pad) const override;
-
-  void CheckType(ScopeStack& env) override;
 };
 
 class ReturnStmtNode : public StmtNode {
@@ -121,8 +110,6 @@ class ReturnStmtNode : public StmtNode {
   int CodeGen() const override;
 
   void Dump(int pad) const override;
-
-  void CheckType(ScopeStack& env) override;
 
   std::unique_ptr<ExprNode> expr_;
 };
@@ -140,8 +127,6 @@ class ExprStmtNode : public StmtNode {
 
   void Dump(int pad) const override;
 
-  void CheckType(ScopeStack& env) override;
-
   std::unique_ptr<ExprNode> expr_;
 };
 
@@ -156,8 +141,6 @@ class IdExprNode : public ExprNode {
 
   void Dump(int pad) const override;
 
-  void CheckType(ScopeStack& env) override;
-
   std::string id_;
 };
 
@@ -171,8 +154,6 @@ class IntConstExprNode : public ExprNode {
   int CodeGen() const override;
 
   void Dump(int pad) const override;
-
-  void CheckType(ScopeStack& env) override;
 
   int val_;
 };
@@ -189,8 +170,6 @@ class BinaryExprNode : public ExprNode {
   int CodeGen() const override;
 
   void Dump(int pad) const override;
-
-  void CheckType(ScopeStack& env) override;
 
   std::unique_ptr<ExprNode> lhs_;
   std::unique_ptr<ExprNode> rhs_;
@@ -351,8 +330,6 @@ class SimpleAssignmentExprNode : public AssignmentExprNode {
   int CodeGen() const override;
 
   void Dump(int pad) const override;
-
-  void CheckType(ScopeStack& env) override;
 
   std::string id_;
   std::unique_ptr<ExprNode> expr_;

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -25,16 +25,16 @@ class AstNode {
 /// @note This is an abstract class.
 class StmtNode : public AstNode {
  public:
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 };
 
 /// @note This is an abstract class.
 class ExprNode : public AstNode {
  public:
   ExprType type = ExprType::kUnknown;
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 };
 
 class DeclNode : public AstNode {
@@ -43,8 +43,8 @@ class DeclNode : public AstNode {
            std::unique_ptr<ExprNode> init = {})
       : id_{id}, type_{decl_type}, init_{std::move(init)} {}
 
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 
   int CodeGen() const override;
 
@@ -62,8 +62,8 @@ class BlockStmtNode : public StmtNode {
                 std::vector<std::unique_ptr<StmtNode>>&& stmts)
       : decls_{std::move(decls)}, stmts_{std::move(stmts)} {}
 
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 
   int CodeGen() const override;
 
@@ -80,8 +80,8 @@ class ProgramNode : public AstNode {
   ProgramNode(std::unique_ptr<BlockStmtNode> block)
       : block_{std::move(block)} {}
 
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 
   int CodeGen() const override;
 
@@ -92,8 +92,8 @@ class ProgramNode : public AstNode {
 
 class NullStmtNode : public StmtNode {
  public:
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 
   int CodeGen() const override;
 
@@ -104,8 +104,8 @@ class ReturnStmtNode : public StmtNode {
  public:
   ReturnStmtNode(std::unique_ptr<ExprNode> expr) : expr_{std::move(expr)} {}
 
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 
   int CodeGen() const override;
 
@@ -120,8 +120,8 @@ class ExprStmtNode : public StmtNode {
  public:
   ExprStmtNode(std::unique_ptr<ExprNode> expr) : expr_{std::move(expr)} {}
 
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 
   int CodeGen() const override;
 
@@ -134,8 +134,8 @@ class IdExprNode : public ExprNode {
  public:
   IdExprNode(const std::string& id) : id_{id} {}
 
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 
   int CodeGen() const override;
 
@@ -148,8 +148,8 @@ class IntConstExprNode : public ExprNode {
  public:
   IntConstExprNode(int val) : val_{val} {}
 
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 
   int CodeGen() const override;
 
@@ -164,8 +164,8 @@ class BinaryExprNode : public ExprNode {
   BinaryExprNode(std::unique_ptr<ExprNode> lhs, std::unique_ptr<ExprNode> rhs)
       : lhs_{std::move(lhs)}, rhs_{std::move(rhs)} {}
 
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 
   int CodeGen() const override;
 
@@ -184,8 +184,8 @@ class PlusExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
 
@@ -196,8 +196,8 @@ class SubExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
 
@@ -208,8 +208,8 @@ class MulExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
 
@@ -220,8 +220,8 @@ class DivExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
 
@@ -232,8 +232,8 @@ class ModExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
 
@@ -244,8 +244,8 @@ class GreaterThanExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
 
@@ -256,8 +256,8 @@ class GreaterThanOrEqualToExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
 
@@ -268,8 +268,8 @@ class LessThanExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
 
@@ -280,8 +280,8 @@ class LessThanOrEqualToExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
 
@@ -292,8 +292,8 @@ class EqualToExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
 
@@ -304,8 +304,8 @@ class NotEqualToExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
  public:
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
 
@@ -315,8 +315,8 @@ class NotEqualToExprNode : public BinaryExprNode {
 /// @note This is an abstract class.
 class AssignmentExprNode : public ExprNode {
  public:
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 };
 
 class SimpleAssignmentExprNode : public AssignmentExprNode {
@@ -324,8 +324,8 @@ class SimpleAssignmentExprNode : public AssignmentExprNode {
   SimpleAssignmentExprNode(std::string id, std::unique_ptr<ExprNode> expr)
       : id_{std::move(id)}, expr_{std::move(expr)} {}
 
-  virtual void Accept(NonModifyingVisitor&) const;
-  virtual void Accept(ModifyingVisitor&);
+  virtual void Accept(NonModifyingVisitor&) const override;
+  virtual void Accept(ModifyingVisitor&) override;
 
   int CodeGen() const override;
 

--- a/include/type_checker.hpp
+++ b/include/type_checker.hpp
@@ -18,6 +18,17 @@ class TypeChecker : public ModifyingVisitor {
   void Visit(IdExprNode&) override;
   void Visit(IntConstExprNode&) override;
   void Visit(BinaryExprNode&) override;
+  void Visit(PlusExprNode&) override;
+  void Visit(SubExprNode&) override;
+  void Visit(MulExprNode&) override;
+  void Visit(DivExprNode&) override;
+  void Visit(ModExprNode&) override;
+  void Visit(GreaterThanExprNode&) override;
+  void Visit(GreaterThanOrEqualToExprNode&) override;
+  void Visit(LessThanExprNode&) override;
+  void Visit(LessThanOrEqualToExprNode&) override;
+  void Visit(EqualToExprNode&) override;
+  void Visit(NotEqualToExprNode&) override;
   void Visit(SimpleAssignmentExprNode&) override;
 
  private:

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -72,6 +72,28 @@ void TypeChecker::Visit(BinaryExprNode& bin_expr) {
   }
 }
 
+/// @brief Dispatch the concrete binary expressions to the parent
+/// `BinaryExprNode`.
+/// @param classname A subclass of `BinaryExprNode`.
+#define DISPATCH_TO_VISIT_BINARY_EXPR(classname) \
+  void TypeChecker::Visit(classname& expr) { \
+    Visit(static_cast<BinaryExprNode&>(expr)); \
+  }
+
+DISPATCH_TO_VISIT_BINARY_EXPR(PlusExprNode);
+DISPATCH_TO_VISIT_BINARY_EXPR(SubExprNode);
+DISPATCH_TO_VISIT_BINARY_EXPR(MulExprNode);
+DISPATCH_TO_VISIT_BINARY_EXPR(DivExprNode);
+DISPATCH_TO_VISIT_BINARY_EXPR(ModExprNode);
+DISPATCH_TO_VISIT_BINARY_EXPR(GreaterThanExprNode);
+DISPATCH_TO_VISIT_BINARY_EXPR(GreaterThanOrEqualToExprNode);
+DISPATCH_TO_VISIT_BINARY_EXPR(LessThanExprNode);
+DISPATCH_TO_VISIT_BINARY_EXPR(LessThanOrEqualToExprNode);
+DISPATCH_TO_VISIT_BINARY_EXPR(EqualToExprNode);
+DISPATCH_TO_VISIT_BINARY_EXPR(NotEqualToExprNode);
+
+#undef DISPATCH_TO_VISIT_BINARY_EXPR
+
 void TypeChecker::Visit(SimpleAssignmentExprNode& assign_expr) {
   assign_expr.expr_->Accept(*this);
   if (auto symbol = env_.LookUp(assign_expr.id_)) {

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -4,7 +4,7 @@
 
 void TypeChecker::Visit(DeclNode& decl) {
   if (decl.init_) {
-    decl.init_->CheckType(env_);
+    decl.init_->Accept(*this);
     if (decl.init_->type != decl.type_) {
       // TODO: incompatible types when initializing type 'type_' using type
       // 'init_->type'
@@ -23,10 +23,10 @@ void TypeChecker::Visit(DeclNode& decl) {
 void TypeChecker::Visit(BlockStmtNode& block) {
   env_.PushScope();
   for (auto& decl : block.decls_) {
-    decl->CheckType(env_);
+    decl->Accept(*this);
   }
   for (auto& stmt : block.stmts_) {
-    stmt->CheckType(env_);
+    stmt->Accept(*this);
   }
   env_.PopScope();
 }
@@ -40,7 +40,7 @@ void TypeChecker::Visit(NullStmtNode&) {
 }
 
 void TypeChecker::Visit(ReturnStmtNode& ret_stmt) {
-  ret_stmt.expr_->CheckType(env_);
+  ret_stmt.expr_->Accept(*this);
   if (ret_stmt.expr_->type != ExprType::kInt) {
     // TODO: return value type does not match the function type
   }


### PR DESCRIPTION
- Replace call to deprecated `TypeCheck`s with call to `Accept`
(fix #39 )
- Remove deprecated `TypeCheck`s

The `TypeChecker` encountered an issue where concrete binary expressions, such as `PlusExprNode`, were erroneously dispatched to the default implementation, resulting in no action being taken.
To resolve this, the `TypeChecker` has to implement the concrete binary expressions, explicitly dispatch them to the parent class `BinaryExprNode`.