### PR TITLE
Avoid slicing on polymorphic objects

### DIFF
--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -20,6 +20,19 @@ class AstNode {
   /// @param pad The length of the padding.
   virtual void Dump(int pad) const = 0;
   virtual ~AstNode() = default;
+  AstNode() = default;
+
+  // Delete copy/move operations to avoid slicing. [1]
+  // And "You almost never want to copy or move polymorphic objects. They
+  // generally live on the heap, and are accessed via (smart) pointers." [2]
+  // [1]
+  // https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-copy-virtual
+  // [2] https://stackoverflow.com/a/54792149
+
+  AstNode(const AstNode&) = delete;
+  AstNode& operator=(const AstNode&) = delete;
+  AstNode(AstNode&&) = delete;
+  AstNode& operator=(AstNode&&) = delete;
 };
 
 /// @note This is an abstract class.


### PR DESCRIPTION
## What's the Problem?

When working with polymorphic objects in C++, it's important to be aware of the issue of slicing.
Slicing occurs because copy and move operations in C++ are non-virtual. This means that if you operate through polymorphism without caution, you risk losing derived class-specific data.

Consider the following example:
```c++
#include <iostream>

struct Base {};

struct Derived : public Base { int i = 0; };

int main() {
  Derived d1{};
  d1.i = 1;
  Derived d2{};
  d2.i = 2;
  Base& d2_ref{d2};

  d2_ref = d1;
  // At first glance, it should make d2.i == d1.i == 1
  // since d2_ref is an alias of d2, but surprisingly, d2.i remains 2.
  // Sliced!
  std::cout << d2.i << '\n';  // 2
  return 0;
}
``` 

We attempt to assign a `Derived` object to a reference of the `Base` class.
This operation seems like it should make `d2.i` equal to `d1.i` (both equal to `1`) since `d2_ref` is an alias of `d2`. However, the result is surprising: `d2.i` remains `2`. This behavior is referred to as "slicing."

To prevent such misuse and avoid slicing, it's advisable to disable copy and move operations for polymorphic objects and use techniques like [polymorphic clone](https://www.fluentcpp.com/2017/09/08/make-polymorphic-copy-modern-cpp/) if necessary. There may also be considerations for implementing a polymorphic move operation when needed.

## See also

- [C.67: A polymorphic class should suppress public copy/move](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-copy-virtual)
-  [How to prevent move slicing?](https://stackoverflow.com/a/54792149)