### PR TITLE
Dump with Visitor pattern

### DIFF
--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -156,8 +156,6 @@ class BinaryExprNode : public ExprNode {
 
   /// @brief The name of the operator used in the QBE IR, e.g., `add`.
   virtual std::string OpName_() const = 0;
-  /// @brief The mathematical symbol of the operator, e.g., `+`.
-  virtual std::string Op_() const = 0;
 };
 
 class PlusExprNode : public BinaryExprNode {
@@ -168,8 +166,6 @@ class PlusExprNode : public BinaryExprNode {
   virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
-
-  std::string Op_() const override;
 };
 
 class SubExprNode : public BinaryExprNode {
@@ -180,8 +176,6 @@ class SubExprNode : public BinaryExprNode {
   virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
-
-  std::string Op_() const override;
 };
 
 class MulExprNode : public BinaryExprNode {
@@ -192,8 +186,6 @@ class MulExprNode : public BinaryExprNode {
   virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
-
-  std::string Op_() const override;
 };
 
 class DivExprNode : public BinaryExprNode {
@@ -204,8 +196,6 @@ class DivExprNode : public BinaryExprNode {
   virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
-
-  std::string Op_() const override;
 };
 
 class ModExprNode : public BinaryExprNode {
@@ -216,8 +206,6 @@ class ModExprNode : public BinaryExprNode {
   virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
-
-  std::string Op_() const override;
 };
 
 class GreaterThanExprNode : public BinaryExprNode {
@@ -228,8 +216,6 @@ class GreaterThanExprNode : public BinaryExprNode {
   virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
-
-  std::string Op_() const override;
 };
 
 class GreaterThanOrEqualToExprNode : public BinaryExprNode {
@@ -240,8 +226,6 @@ class GreaterThanOrEqualToExprNode : public BinaryExprNode {
   virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
-
-  std::string Op_() const override;
 };
 
 class LessThanExprNode : public BinaryExprNode {
@@ -252,8 +236,6 @@ class LessThanExprNode : public BinaryExprNode {
   virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
-
-  std::string Op_() const override;
 };
 
 class LessThanOrEqualToExprNode : public BinaryExprNode {
@@ -264,8 +246,6 @@ class LessThanOrEqualToExprNode : public BinaryExprNode {
   virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
-
-  std::string Op_() const override;
 };
 
 class EqualToExprNode : public BinaryExprNode {
@@ -276,8 +256,6 @@ class EqualToExprNode : public BinaryExprNode {
   virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
-
-  std::string Op_() const override;
 };
 
 class NotEqualToExprNode : public BinaryExprNode {
@@ -288,8 +266,6 @@ class NotEqualToExprNode : public BinaryExprNode {
   virtual void Accept(ModifyingVisitor&) override;
 
   std::string OpName_() const override;
-
-  std::string Op_() const override;
 };
 
 /// @note This is an abstract class.

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -17,8 +17,6 @@ class AstNode {
   virtual void Accept(ModifyingVisitor&);
 
   virtual int CodeGen() const = 0;
-  /// @param pad The length of the padding.
-  virtual void Dump(int pad) const = 0;
   virtual ~AstNode() = default;
 };
 
@@ -48,8 +46,6 @@ class DeclNode : public AstNode {
 
   int CodeGen() const override;
 
-  void Dump(int pad) const override;
-
   std::string id_;
   ExprType type_;
   std::unique_ptr<ExprNode> init_;
@@ -67,8 +63,6 @@ class BlockStmtNode : public StmtNode {
 
   int CodeGen() const override;
 
-  void Dump(int pad) const override;
-
   std::vector<std::unique_ptr<DeclNode>> decls_;
   std::vector<std::unique_ptr<StmtNode>> stmts_;
 };
@@ -85,8 +79,6 @@ class ProgramNode : public AstNode {
 
   int CodeGen() const override;
 
-  void Dump(int pad) const override;
-
   std::unique_ptr<BlockStmtNode> block_;
 };
 
@@ -96,8 +88,6 @@ class NullStmtNode : public StmtNode {
   virtual void Accept(ModifyingVisitor&) override;
 
   int CodeGen() const override;
-
-  void Dump(int pad) const override;
 };
 
 class ReturnStmtNode : public StmtNode {
@@ -108,8 +98,6 @@ class ReturnStmtNode : public StmtNode {
   virtual void Accept(ModifyingVisitor&) override;
 
   int CodeGen() const override;
-
-  void Dump(int pad) const override;
 
   std::unique_ptr<ExprNode> expr_;
 };
@@ -125,8 +113,6 @@ class ExprStmtNode : public StmtNode {
 
   int CodeGen() const override;
 
-  void Dump(int pad) const override;
-
   std::unique_ptr<ExprNode> expr_;
 };
 
@@ -139,8 +125,6 @@ class IdExprNode : public ExprNode {
 
   int CodeGen() const override;
 
-  void Dump(int pad) const override;
-
   std::string id_;
 };
 
@@ -152,8 +136,6 @@ class IntConstExprNode : public ExprNode {
   virtual void Accept(ModifyingVisitor&) override;
 
   int CodeGen() const override;
-
-  void Dump(int pad) const override;
 
   int val_;
 };
@@ -168,8 +150,6 @@ class BinaryExprNode : public ExprNode {
   virtual void Accept(ModifyingVisitor&) override;
 
   int CodeGen() const override;
-
-  void Dump(int pad) const override;
 
   std::unique_ptr<ExprNode> lhs_;
   std::unique_ptr<ExprNode> rhs_;
@@ -328,8 +308,6 @@ class SimpleAssignmentExprNode : public AssignmentExprNode {
   virtual void Accept(ModifyingVisitor&) override;
 
   int CodeGen() const override;
-
-  void Dump(int pad) const override;
 
   std::string id_;
   std::unique_ptr<ExprNode> expr_;

--- a/include/ast_dumper.hpp
+++ b/include/ast_dumper.hpp
@@ -1,6 +1,7 @@
 #ifndef AST_DUMPER_HPP_
 #define AST_DUMPER_HPP_
 
+#include "util.hpp"
 #include "visitor.hpp"
 
 class AstDumper : public NonModifyingVisitor {
@@ -26,6 +27,11 @@ class AstDumper : public NonModifyingVisitor {
   void Visit(const EqualToExprNode&) override;
   void Visit(const NotEqualToExprNode&) override;
   void Visit(const SimpleAssignmentExprNode&) override;
+
+  AstDumper(Indenter& indenter) : indenter_{indenter} {}
+
+ private:
+  Indenter& indenter_;
 };
 
 #endif  // AST_DUMPER_HPP_

--- a/include/ast_dumper.hpp
+++ b/include/ast_dumper.hpp
@@ -1,0 +1,31 @@
+#ifndef AST_DUMPER_HPP_
+#define AST_DUMPER_HPP_
+
+#include "visitor.hpp"
+
+class AstDumper : public NonModifyingVisitor {
+ public:
+  void Visit(const DeclNode&) override;
+  void Visit(const BlockStmtNode&) override;
+  void Visit(const ProgramNode&) override;
+  void Visit(const NullStmtNode&) override;
+  void Visit(const ReturnStmtNode&) override;
+  void Visit(const ExprStmtNode&) override;
+  void Visit(const IdExprNode&) override;
+  void Visit(const IntConstExprNode&) override;
+  void Visit(const BinaryExprNode&) override;
+  void Visit(const PlusExprNode&) override;
+  void Visit(const SubExprNode&) override;
+  void Visit(const MulExprNode&) override;
+  void Visit(const DivExprNode&) override;
+  void Visit(const ModExprNode&) override;
+  void Visit(const GreaterThanExprNode&) override;
+  void Visit(const GreaterThanOrEqualToExprNode&) override;
+  void Visit(const LessThanExprNode&) override;
+  void Visit(const LessThanOrEqualToExprNode&) override;
+  void Visit(const EqualToExprNode&) override;
+  void Visit(const NotEqualToExprNode&) override;
+  void Visit(const SimpleAssignmentExprNode&) override;
+};
+
+#endif  // AST_DUMPER_HPP_

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -1,0 +1,35 @@
+#ifndef UTIL_HPP_
+#define UTIL_HPP_
+
+#include <cstddef>
+#include <string>
+
+class Indenter {
+ public:
+  /// @return `size_per_level` * `level` number of `symbol`s.
+  std::string Indent() const;
+
+  void IncreaseLevel();
+
+  /// @note The indention level saturates at 0.
+  void DecreaseLevel();
+
+  /// @param symbol The symbol used to indent with.
+  /// @param size_per_level The indention size. For example, if the size is `2`,
+  /// each indention level adds 2 `symbol`s.
+  /// @param max_level If equals to `0`, there is no limit.
+  Indenter(char symbol, std::size_t size_per_level, std::size_t max_level = 0)
+      : symbol_{symbol},
+        size_per_level_{size_per_level},
+        max_level_{max_level} {}
+
+ private:
+  char symbol_;
+  std::size_t size_per_level_;
+  std::size_t max_level_;
+  std::size_t level_{0};
+
+  bool HasNoLevelLimit_() const;
+};
+
+#endif  // UTIL_HPP_

--- a/main.cpp
+++ b/main.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "ast.hpp"
+#include "ast_dumper.hpp"
 #include "scope.hpp"
 #include "type_checker.hpp"
 #include "y.tab.h"
@@ -48,7 +49,8 @@ int main(int argc, char** argv) {
   auto type_checker = TypeChecker{scopes};
   program->Accept(type_checker);
   if (args["dump"].as<bool>()) {
-    program->Dump(0);
+    auto ast_dumper = AstDumper{};
+    program->Accept(ast_dumper);
   }
   program->CodeGen();
 

--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,7 @@
 #include "ast_dumper.hpp"
 #include "scope.hpp"
 #include "type_checker.hpp"
+#include "util.hpp"
 #include "y.tab.h"
 
 /// @brief Where the generated code goes.
@@ -49,7 +50,8 @@ int main(int argc, char** argv) {
   auto type_checker = TypeChecker{scopes};
   program->Accept(type_checker);
   if (args["dump"].as<bool>()) {
-    auto ast_dumper = AstDumper{};
+    auto indenter = Indenter{' ', 2, 80};
+    auto ast_dumper = AstDumper{indenter};
     program->Accept(ast_dumper);
   }
   program->CodeGen();

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -219,10 +219,6 @@ std::string PlusExprNode::OpName_() const {
   return "add";
 }
 
-std::string PlusExprNode::Op_() const {
-  return "+";
-}
-
 void SubExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
@@ -233,10 +229,6 @@ void SubExprNode::Accept(ModifyingVisitor& v) {
 
 std::string SubExprNode::OpName_() const {
   return "sub";
-}
-
-std::string SubExprNode::Op_() const {
-  return "-";
 }
 
 void MulExprNode::Accept(NonModifyingVisitor& v) const {
@@ -251,10 +243,6 @@ std::string MulExprNode::OpName_() const {
   return "mul";
 }
 
-std::string MulExprNode::Op_() const {
-  return "*";
-}
-
 void DivExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
@@ -267,10 +255,6 @@ std::string DivExprNode::OpName_() const {
   return "div";
 }
 
-std::string DivExprNode::Op_() const {
-  return "/";
-}
-
 void ModExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
@@ -281,10 +265,6 @@ void ModExprNode::Accept(ModifyingVisitor& v) {
 
 std::string ModExprNode::OpName_() const {
   return "rem";
-}
-
-std::string ModExprNode::Op_() const {
-  return "%";
 }
 
 void GreaterThanExprNode::Accept(NonModifyingVisitor& v) const {
@@ -300,10 +280,6 @@ std::string GreaterThanExprNode::OpName_() const {
   return "sgt";
 }
 
-std::string GreaterThanExprNode::Op_() const {
-  return ">";
-}
-
 void GreaterThanOrEqualToExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
@@ -315,10 +291,6 @@ void GreaterThanOrEqualToExprNode::Accept(ModifyingVisitor& v) {
 std::string GreaterThanOrEqualToExprNode::OpName_() const {
   // signed
   return "sge";
-}
-
-std::string GreaterThanOrEqualToExprNode::Op_() const {
-  return ">=";
 }
 
 void LessThanExprNode::Accept(NonModifyingVisitor& v) const {
@@ -334,10 +306,6 @@ std::string LessThanExprNode::OpName_() const {
   return "slt";
 }
 
-std::string LessThanExprNode::Op_() const {
-  return "<";
-}
-
 void LessThanOrEqualToExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
@@ -349,10 +317,6 @@ void LessThanOrEqualToExprNode::Accept(ModifyingVisitor& v) {
 std::string LessThanOrEqualToExprNode::OpName_() const {
   // signed
   return "sle";
-}
-
-std::string LessThanOrEqualToExprNode::Op_() const {
-  return "<=";
 }
 
 void EqualToExprNode::Accept(NonModifyingVisitor& v) const {
@@ -367,10 +331,6 @@ std::string EqualToExprNode::OpName_() const {
   return "eq";
 }
 
-std::string EqualToExprNode::Op_() const {
-  return "==";
-}
-
 void NotEqualToExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
@@ -381,10 +341,6 @@ void NotEqualToExprNode::Accept(ModifyingVisitor& v) {
 
 std::string NotEqualToExprNode::OpName_() const {
   return "ne";
-}
-
-std::string NotEqualToExprNode::Op_() const {
-  return "!=";
 }
 
 void AssignmentExprNode::Accept(NonModifyingVisitor& v) const {

--- a/src/ast_dumpr.cpp
+++ b/src/ast_dumpr.cpp
@@ -1,0 +1,142 @@
+#include <cstddef>
+#include <iostream>
+#include <string>
+
+#include "ast.hpp"
+#include "ast_dumper.hpp"
+#include "type.hpp"
+
+namespace {
+
+class Indenter {
+ public:
+  /// @return `size_per_level` * `level` number of `symbol`s.
+  std::string Indent() const {
+    return std::string(size_per_level_ * level_, symbol_);
+  }
+
+  void IncreaseLevel() {
+    if (level_ == 0 /* no limit */ || level_ < max_level_) {
+      ++level_;
+    }
+  }
+
+  void DecreaseLevel() {
+    if (level_) {
+      --level_;
+    }
+  }
+
+  /// @param symbol The symbol used to indent with.
+  /// @param size_per_level The indention size. For example, if the size is `2`,
+  /// each indention level adds 2 `symbol`s.
+  /// @param max_level If equals to `0`, there is no limit.
+  Indenter(char symbol, std::size_t size_per_level, std::size_t max_level = 0)
+      : symbol_{symbol},
+        size_per_level_{size_per_level},
+        max_level_{max_level} {}
+
+ private:
+  char symbol_;
+  std::size_t size_per_level_;
+  std::size_t max_level_;
+  std::size_t level_{0};
+};
+
+auto indenter = Indenter{' ', 2, 80};
+
+}  // namespace
+
+void AstDumper::Visit(const DeclNode& decl) {
+  std::cout << indenter.Indent() << '(' << decl.id_ << ": "
+            << ExprTypeToCString(decl.type_);
+  if (decl.init_) {
+    std::cout << " =" << std::endl;
+    indenter.IncreaseLevel();
+    decl.init_->Accept(*this);
+    indenter.DecreaseLevel();
+  }
+  std::cout << ')' << std::endl;
+}
+
+void AstDumper::Visit(const BlockStmtNode& block) {
+  for (const auto& decl : block.decls_) {
+    decl->Accept(*this);
+  }
+  for (const auto& stmt : block.stmts_) {
+    stmt->Accept(*this);
+  }
+}
+
+void AstDumper::Visit(const ProgramNode& program) {
+  program.block_->Accept(*this);
+}
+
+void AstDumper::Visit(const NullStmtNode& stmt) {
+  std::cout << indenter.Indent() << "()" << std::endl;
+}
+
+void AstDumper::Visit(const ReturnStmtNode& ret_stmt) {
+  std::cout << indenter.Indent() << "(ret" << std::endl;
+  indenter.IncreaseLevel();
+  ret_stmt.expr_->Accept(*this);
+  indenter.DecreaseLevel();
+  std::cout << indenter.Indent() << ')' << std::endl;
+}
+
+void AstDumper::Visit(const ExprStmtNode& expr_stmt) {
+  expr_stmt.expr_->Accept(*this);
+}
+
+void AstDumper::Visit(const IdExprNode& id_expr) {
+  std::cout << indenter.Indent() << id_expr.id_ << ": "
+            << ExprTypeToCString(id_expr.type) << std::endl;
+}
+
+void AstDumper::Visit(const IntConstExprNode& int_expr) {
+  std::cout << indenter.Indent() << int_expr.val_ << ": "
+            << ExprTypeToCString(int_expr.type) << std::endl;
+}
+
+void AstDumper::Visit(const BinaryExprNode& bin_expr) {
+  std::cout << indenter.Indent() << '(' << bin_expr.Op_() << std::endl;
+  indenter.IncreaseLevel();
+  bin_expr.lhs_->Accept(*this);
+  bin_expr.rhs_->Accept(*this);
+  indenter.DecreaseLevel();
+  std::cout << indenter.Indent() << ')' << ": "
+            << ExprTypeToCString(bin_expr.type) << std::endl;
+}
+
+/// @brief Dispatch the concrete binary expressions to the parent
+/// `BinaryExprNode`.
+/// @param classname A subclass of `BinaryExprNode`.
+#define DISPATCH_TO_VISIT_BINARY_EXPR(classname) \
+  void AstDumper::Visit(const classname& expr) { \
+    Visit(static_cast<const BinaryExprNode&>(expr)); \
+  }
+
+DISPATCH_TO_VISIT_BINARY_EXPR(PlusExprNode);
+DISPATCH_TO_VISIT_BINARY_EXPR(SubExprNode);
+DISPATCH_TO_VISIT_BINARY_EXPR(MulExprNode);
+DISPATCH_TO_VISIT_BINARY_EXPR(DivExprNode);
+DISPATCH_TO_VISIT_BINARY_EXPR(ModExprNode);
+DISPATCH_TO_VISIT_BINARY_EXPR(GreaterThanExprNode);
+DISPATCH_TO_VISIT_BINARY_EXPR(GreaterThanOrEqualToExprNode);
+DISPATCH_TO_VISIT_BINARY_EXPR(LessThanExprNode);
+DISPATCH_TO_VISIT_BINARY_EXPR(LessThanOrEqualToExprNode);
+DISPATCH_TO_VISIT_BINARY_EXPR(EqualToExprNode);
+DISPATCH_TO_VISIT_BINARY_EXPR(NotEqualToExprNode);
+
+#undef DISPATCH_TO_VISIT_BINARY_EXPR
+
+void AstDumper::Visit(const SimpleAssignmentExprNode& assign_expr) {
+  std::cout << indenter.Indent() << '(' << '=' << std::endl;
+  indenter.IncreaseLevel();
+  std::cout << indenter.Indent() << assign_expr.id_ << ": "
+            << ExprTypeToCString(assign_expr.type) << std::endl;
+  assign_expr.expr_->Accept(*this);
+  indenter.DecreaseLevel();
+  std::cout << indenter.Indent() << ')' << ": "
+            << ExprTypeToCString(assign_expr.expr_->type) << std::endl;
+}

--- a/src/ast_dumpr.cpp
+++ b/src/ast_dumpr.cpp
@@ -1,47 +1,11 @@
-#include <cstddef>
 #include <iostream>
-#include <string>
 
 #include "ast.hpp"
 #include "ast_dumper.hpp"
 #include "type.hpp"
+#include "util.hpp"
 
 namespace {
-
-class Indenter {
- public:
-  /// @return `size_per_level` * `level` number of `symbol`s.
-  std::string Indent() const {
-    return std::string(size_per_level_ * level_, symbol_);
-  }
-
-  void IncreaseLevel() {
-    if (level_ == 0 /* no limit */ || level_ < max_level_) {
-      ++level_;
-    }
-  }
-
-  void DecreaseLevel() {
-    if (level_) {
-      --level_;
-    }
-  }
-
-  /// @param symbol The symbol used to indent with.
-  /// @param size_per_level The indention size. For example, if the size is `2`,
-  /// each indention level adds 2 `symbol`s.
-  /// @param max_level If equals to `0`, there is no limit.
-  Indenter(char symbol, std::size_t size_per_level, std::size_t max_level = 0)
-      : symbol_{symbol},
-        size_per_level_{size_per_level},
-        max_level_{max_level} {}
-
- private:
-  char symbol_;
-  std::size_t size_per_level_;
-  std::size_t max_level_;
-  std::size_t level_{0};
-};
 
 auto indenter = Indenter{' ', 2, 80};
 

--- a/src/ast_dumpr.cpp
+++ b/src/ast_dumpr.cpp
@@ -3,22 +3,15 @@
 #include "ast.hpp"
 #include "ast_dumper.hpp"
 #include "type.hpp"
-#include "util.hpp"
-
-namespace {
-
-auto indenter = Indenter{' ', 2, 80};
-
-}  // namespace
 
 void AstDumper::Visit(const DeclNode& decl) {
-  std::cout << indenter.Indent() << '(' << decl.id_ << ": "
+  std::cout << indenter_.Indent() << '(' << decl.id_ << ": "
             << ExprTypeToCString(decl.type_);
   if (decl.init_) {
     std::cout << " =" << std::endl;
-    indenter.IncreaseLevel();
+    indenter_.IncreaseLevel();
     decl.init_->Accept(*this);
-    indenter.DecreaseLevel();
+    indenter_.DecreaseLevel();
   }
   std::cout << ')' << std::endl;
 }
@@ -37,15 +30,15 @@ void AstDumper::Visit(const ProgramNode& program) {
 }
 
 void AstDumper::Visit(const NullStmtNode& stmt) {
-  std::cout << indenter.Indent() << "()" << std::endl;
+  std::cout << indenter_.Indent() << "()" << std::endl;
 }
 
 void AstDumper::Visit(const ReturnStmtNode& ret_stmt) {
-  std::cout << indenter.Indent() << "(ret" << std::endl;
-  indenter.IncreaseLevel();
+  std::cout << indenter_.Indent() << "(ret" << std::endl;
+  indenter_.IncreaseLevel();
   ret_stmt.expr_->Accept(*this);
-  indenter.DecreaseLevel();
-  std::cout << indenter.Indent() << ')' << std::endl;
+  indenter_.DecreaseLevel();
+  std::cout << indenter_.Indent() << ')' << std::endl;
 }
 
 void AstDumper::Visit(const ExprStmtNode& expr_stmt) {
@@ -53,22 +46,22 @@ void AstDumper::Visit(const ExprStmtNode& expr_stmt) {
 }
 
 void AstDumper::Visit(const IdExprNode& id_expr) {
-  std::cout << indenter.Indent() << id_expr.id_ << ": "
+  std::cout << indenter_.Indent() << id_expr.id_ << ": "
             << ExprTypeToCString(id_expr.type) << std::endl;
 }
 
 void AstDumper::Visit(const IntConstExprNode& int_expr) {
-  std::cout << indenter.Indent() << int_expr.val_ << ": "
+  std::cout << indenter_.Indent() << int_expr.val_ << ": "
             << ExprTypeToCString(int_expr.type) << std::endl;
 }
 
 void AstDumper::Visit(const BinaryExprNode& bin_expr) {
-  std::cout << indenter.Indent() << '(' << bin_expr.Op_() << std::endl;
-  indenter.IncreaseLevel();
+  std::cout << indenter_.Indent() << '(' << bin_expr.Op_() << std::endl;
+  indenter_.IncreaseLevel();
   bin_expr.lhs_->Accept(*this);
   bin_expr.rhs_->Accept(*this);
-  indenter.DecreaseLevel();
-  std::cout << indenter.Indent() << ')' << ": "
+  indenter_.DecreaseLevel();
+  std::cout << indenter_.Indent() << ')' << ": "
             << ExprTypeToCString(bin_expr.type) << std::endl;
 }
 
@@ -95,12 +88,12 @@ DISPATCH_TO_VISIT_BINARY_EXPR(NotEqualToExprNode);
 #undef DISPATCH_TO_VISIT_BINARY_EXPR
 
 void AstDumper::Visit(const SimpleAssignmentExprNode& assign_expr) {
-  std::cout << indenter.Indent() << '(' << '=' << std::endl;
-  indenter.IncreaseLevel();
-  std::cout << indenter.Indent() << assign_expr.id_ << ": "
+  std::cout << indenter_.Indent() << '(' << '=' << std::endl;
+  indenter_.IncreaseLevel();
+  std::cout << indenter_.Indent() << assign_expr.id_ << ": "
             << ExprTypeToCString(assign_expr.type) << std::endl;
   assign_expr.expr_->Accept(*this);
-  indenter.DecreaseLevel();
-  std::cout << indenter.Indent() << ')' << ": "
+  indenter_.DecreaseLevel();
+  std::cout << indenter_.Indent() << ')' << ": "
             << ExprTypeToCString(assign_expr.expr_->type) << std::endl;
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,0 +1,24 @@
+#include "util.hpp"
+
+#include <cstddef>
+#include <string>
+
+std::string Indenter::Indent() const {
+  return std::string(size_per_level_ * level_, symbol_);
+}
+
+void Indenter::IncreaseLevel() {
+  if (HasNoLevelLimit_() || level_ < max_level_) {
+    ++level_;
+  }
+}
+
+void Indenter::DecreaseLevel() {
+  if (level_) {
+    --level_;
+  }
+}
+
+bool Indenter::HasNoLevelLimit_() const {
+  return 0 == max_level_;
+}


### PR DESCRIPTION
This PR follows the same concept as #39, with the removal of deprecated `Dump` functions.
To improve code structure, I introduce a new object, `Indenter`, which handles indention details.

One potentially complex aspect is how we retrieve the `Op`s of `BinaryExprNode`s. This is accomplished using a hidden Visitor pattern. It's stateless and utilized only once in the `Visit` function of `BinaryExprNode`. As such, I've constructed it in-place rather than as a static global object or a data member of `AstDumpr`. For more details, please review the `OpGetter` class and its accompanying internal comments.
