### PR TITLE
Convert AST nodes to struct & remove suffix from public data members

### DIFF
--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -58,14 +58,14 @@ class DeclNode : public AstNode {
  public:
   DeclNode(const std::string& id, ExprType decl_type,
            std::unique_ptr<ExprNode> init = {})
-      : id_{id}, type_{decl_type}, init_{std::move(init)} {}
+      : id{id}, type{decl_type}, init{std::move(init)} {}
 
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 
-  std::string id_;
-  ExprType type_;
-  std::unique_ptr<ExprNode> init_;
+  std::string id;
+  ExprType type;
+  std::unique_ptr<ExprNode> init;
 };
 
 /// @brief A block is a set of declarations and statements.
@@ -73,26 +73,25 @@ class BlockStmtNode : public StmtNode {
  public:
   BlockStmtNode(std::vector<std::unique_ptr<DeclNode>>&& decls,
                 std::vector<std::unique_ptr<StmtNode>>&& stmts)
-      : decls_{std::move(decls)}, stmts_{std::move(stmts)} {}
+      : decls{std::move(decls)}, stmts{std::move(stmts)} {}
 
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 
-  std::vector<std::unique_ptr<DeclNode>> decls_;
-  std::vector<std::unique_ptr<StmtNode>> stmts_;
+  std::vector<std::unique_ptr<DeclNode>> decls;
+  std::vector<std::unique_ptr<StmtNode>> stmts;
 };
 
 /// @brief Root of the entire program.
 class ProgramNode : public AstNode {
  public:
   /// @note vector of move-only elements are move-only
-  ProgramNode(std::unique_ptr<BlockStmtNode> block)
-      : block_{std::move(block)} {}
+  ProgramNode(std::unique_ptr<BlockStmtNode> block) : block{std::move(block)} {}
 
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 
-  std::unique_ptr<BlockStmtNode> block_;
+  std::unique_ptr<BlockStmtNode> block;
 };
 
 class NullStmtNode : public StmtNode {
@@ -103,51 +102,51 @@ class NullStmtNode : public StmtNode {
 
 class ReturnStmtNode : public StmtNode {
  public:
-  ReturnStmtNode(std::unique_ptr<ExprNode> expr) : expr_{std::move(expr)} {}
+  ReturnStmtNode(std::unique_ptr<ExprNode> expr) : expr{std::move(expr)} {}
 
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 
-  std::unique_ptr<ExprNode> expr_;
+  std::unique_ptr<ExprNode> expr;
 };
 
 /// @note Any expression can be turned into a statement by adding a semicolon
 /// to the end of the expression.
 class ExprStmtNode : public StmtNode {
  public:
-  ExprStmtNode(std::unique_ptr<ExprNode> expr) : expr_{std::move(expr)} {}
+  ExprStmtNode(std::unique_ptr<ExprNode> expr) : expr{std::move(expr)} {}
 
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 
-  std::unique_ptr<ExprNode> expr_;
+  std::unique_ptr<ExprNode> expr;
 };
 
 class IdExprNode : public ExprNode {
  public:
-  IdExprNode(const std::string& id) : id_{id} {}
+  IdExprNode(const std::string& id) : id{id} {}
 
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 
-  std::string id_;
+  std::string id;
 };
 
 class IntConstExprNode : public ExprNode {
  public:
-  IntConstExprNode(int val) : val_{val} {}
+  IntConstExprNode(int val) : val{val} {}
 
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 
-  int val_;
+  int val;
 };
 
 /// @note This is an abstract class.
 class BinaryExprNode : public ExprNode {
  public:
   BinaryExprNode(std::unique_ptr<ExprNode> lhs, std::unique_ptr<ExprNode> rhs)
-      : lhs_{std::move(lhs)}, rhs_{std::move(rhs)} {}
+      : lhs{std::move(lhs)}, rhs{std::move(rhs)} {}
 
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
@@ -155,8 +154,8 @@ class BinaryExprNode : public ExprNode {
   /// @note To make the class abstract.
   virtual ~BinaryExprNode() = 0;
 
-  std::unique_ptr<ExprNode> lhs_;
-  std::unique_ptr<ExprNode> rhs_;
+  std::unique_ptr<ExprNode> lhs;
+  std::unique_ptr<ExprNode> rhs;
 };
 
 class PlusExprNode : public BinaryExprNode {
@@ -260,13 +259,13 @@ class AssignmentExprNode : public ExprNode {
 class SimpleAssignmentExprNode : public AssignmentExprNode {
  public:
   SimpleAssignmentExprNode(std::string id, std::unique_ptr<ExprNode> expr)
-      : id_{std::move(id)}, expr_{std::move(expr)} {}
+      : id{std::move(id)}, expr{std::move(expr)} {}
 
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 
-  std::string id_;
-  std::unique_ptr<ExprNode> expr_;
+  std::string id;
+  std::unique_ptr<ExprNode> expr;
 };
 
 #endif  // AST_HPP_

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -11,8 +11,7 @@
 
 /// @brief The most general base node of the Abstract Syntax Tree.
 /// @note This is an abstract class.
-class AstNode {
- public:
+struct AstNode {
   virtual void Accept(NonModifyingVisitor&) const;
   virtual void Accept(ModifyingVisitor&);
 
@@ -34,8 +33,7 @@ class AstNode {
 };
 
 /// @note This is an abstract class.
-class StmtNode : public AstNode {
- public:
+struct StmtNode : public AstNode {
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 
@@ -44,8 +42,7 @@ class StmtNode : public AstNode {
 };
 
 /// @note This is an abstract class.
-class ExprNode : public AstNode {
- public:
+struct ExprNode : public AstNode {
   ExprType type = ExprType::kUnknown;
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
@@ -54,8 +51,7 @@ class ExprNode : public AstNode {
   virtual ~ExprNode() = 0;
 };
 
-class DeclNode : public AstNode {
- public:
+struct DeclNode : public AstNode {
   DeclNode(const std::string& id, ExprType decl_type,
            std::unique_ptr<ExprNode> init = {})
       : id{id}, type{decl_type}, init{std::move(init)} {}
@@ -69,8 +65,7 @@ class DeclNode : public AstNode {
 };
 
 /// @brief A block is a set of declarations and statements.
-class BlockStmtNode : public StmtNode {
- public:
+struct BlockStmtNode : public StmtNode {
   BlockStmtNode(std::vector<std::unique_ptr<DeclNode>>&& decls,
                 std::vector<std::unique_ptr<StmtNode>>&& stmts)
       : decls{std::move(decls)}, stmts{std::move(stmts)} {}
@@ -83,8 +78,7 @@ class BlockStmtNode : public StmtNode {
 };
 
 /// @brief Root of the entire program.
-class ProgramNode : public AstNode {
- public:
+struct ProgramNode : public AstNode {
   /// @note vector of move-only elements are move-only
   ProgramNode(std::unique_ptr<BlockStmtNode> block) : block{std::move(block)} {}
 
@@ -94,14 +88,12 @@ class ProgramNode : public AstNode {
   std::unique_ptr<BlockStmtNode> block;
 };
 
-class NullStmtNode : public StmtNode {
- public:
+struct NullStmtNode : public StmtNode {
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 };
 
-class ReturnStmtNode : public StmtNode {
- public:
+struct ReturnStmtNode : public StmtNode {
   ReturnStmtNode(std::unique_ptr<ExprNode> expr) : expr{std::move(expr)} {}
 
   virtual void Accept(NonModifyingVisitor&) const override;
@@ -112,8 +104,7 @@ class ReturnStmtNode : public StmtNode {
 
 /// @note Any expression can be turned into a statement by adding a semicolon
 /// to the end of the expression.
-class ExprStmtNode : public StmtNode {
- public:
+struct ExprStmtNode : public StmtNode {
   ExprStmtNode(std::unique_ptr<ExprNode> expr) : expr{std::move(expr)} {}
 
   virtual void Accept(NonModifyingVisitor&) const override;
@@ -122,8 +113,7 @@ class ExprStmtNode : public StmtNode {
   std::unique_ptr<ExprNode> expr;
 };
 
-class IdExprNode : public ExprNode {
- public:
+struct IdExprNode : public ExprNode {
   IdExprNode(const std::string& id) : id{id} {}
 
   virtual void Accept(NonModifyingVisitor&) const override;
@@ -132,8 +122,7 @@ class IdExprNode : public ExprNode {
   std::string id;
 };
 
-class IntConstExprNode : public ExprNode {
- public:
+struct IntConstExprNode : public ExprNode {
   IntConstExprNode(int val) : val{val} {}
 
   virtual void Accept(NonModifyingVisitor&) const override;
@@ -143,8 +132,7 @@ class IntConstExprNode : public ExprNode {
 };
 
 /// @note This is an abstract class.
-class BinaryExprNode : public ExprNode {
- public:
+struct BinaryExprNode : public ExprNode {
   BinaryExprNode(std::unique_ptr<ExprNode> lhs, std::unique_ptr<ExprNode> rhs)
       : lhs{std::move(lhs)}, rhs{std::move(rhs)} {}
 
@@ -158,97 +146,85 @@ class BinaryExprNode : public ExprNode {
   std::unique_ptr<ExprNode> rhs;
 };
 
-class PlusExprNode : public BinaryExprNode {
+struct PlusExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
- public:
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 };
 
-class SubExprNode : public BinaryExprNode {
+struct SubExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
- public:
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 };
 
-class MulExprNode : public BinaryExprNode {
+struct MulExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
- public:
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 };
 
-class DivExprNode : public BinaryExprNode {
+struct DivExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
- public:
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 };
 
-class ModExprNode : public BinaryExprNode {
+struct ModExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
- public:
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 };
 
-class GreaterThanExprNode : public BinaryExprNode {
+struct GreaterThanExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
- public:
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 };
 
-class GreaterThanOrEqualToExprNode : public BinaryExprNode {
+struct GreaterThanOrEqualToExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
- public:
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 };
 
-class LessThanExprNode : public BinaryExprNode {
+struct LessThanExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
- public:
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 };
 
-class LessThanOrEqualToExprNode : public BinaryExprNode {
+struct LessThanOrEqualToExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
- public:
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 };
 
-class EqualToExprNode : public BinaryExprNode {
+struct EqualToExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
- public:
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 };
 
-class NotEqualToExprNode : public BinaryExprNode {
+struct NotEqualToExprNode : public BinaryExprNode {
   using BinaryExprNode::BinaryExprNode;
 
- public:
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 };
 
 /// @note This is an abstract class.
-class AssignmentExprNode : public ExprNode {
- public:
+struct AssignmentExprNode : public ExprNode {
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;
 
@@ -256,8 +232,7 @@ class AssignmentExprNode : public ExprNode {
   virtual ~AssignmentExprNode() = 0;
 };
 
-class SimpleAssignmentExprNode : public AssignmentExprNode {
- public:
+struct SimpleAssignmentExprNode : public AssignmentExprNode {
   SimpleAssignmentExprNode(std::string id, std::unique_ptr<ExprNode> expr)
       : id{std::move(id)}, expr{std::move(expr)} {}
 

--- a/src/ast_dumpr.cpp
+++ b/src/ast_dumpr.cpp
@@ -28,28 +28,28 @@ class OpGetter {
 }  // namespace
 
 void AstDumper::Visit(const DeclNode& decl) {
-  std::cout << indenter_.Indent() << '(' << decl.id_ << ": "
-            << ExprTypeToCString(decl.type_);
-  if (decl.init_) {
+  std::cout << indenter_.Indent() << '(' << decl.id << ": "
+            << ExprTypeToCString(decl.type);
+  if (decl.init) {
     std::cout << " =" << std::endl;
     indenter_.IncreaseLevel();
-    decl.init_->Accept(*this);
+    decl.init->Accept(*this);
     indenter_.DecreaseLevel();
   }
   std::cout << ')' << std::endl;
 }
 
 void AstDumper::Visit(const BlockStmtNode& block) {
-  for (const auto& decl : block.decls_) {
+  for (const auto& decl : block.decls) {
     decl->Accept(*this);
   }
-  for (const auto& stmt : block.stmts_) {
+  for (const auto& stmt : block.stmts) {
     stmt->Accept(*this);
   }
 }
 
 void AstDumper::Visit(const ProgramNode& program) {
-  program.block_->Accept(*this);
+  program.block->Accept(*this);
 }
 
 void AstDumper::Visit(const NullStmtNode& stmt) {
@@ -59,22 +59,22 @@ void AstDumper::Visit(const NullStmtNode& stmt) {
 void AstDumper::Visit(const ReturnStmtNode& ret_stmt) {
   std::cout << indenter_.Indent() << "(ret" << std::endl;
   indenter_.IncreaseLevel();
-  ret_stmt.expr_->Accept(*this);
+  ret_stmt.expr->Accept(*this);
   indenter_.DecreaseLevel();
   std::cout << indenter_.Indent() << ')' << std::endl;
 }
 
 void AstDumper::Visit(const ExprStmtNode& expr_stmt) {
-  expr_stmt.expr_->Accept(*this);
+  expr_stmt.expr->Accept(*this);
 }
 
 void AstDumper::Visit(const IdExprNode& id_expr) {
-  std::cout << indenter_.Indent() << id_expr.id_ << ": "
+  std::cout << indenter_.Indent() << id_expr.id << ": "
             << ExprTypeToCString(id_expr.type) << std::endl;
 }
 
 void AstDumper::Visit(const IntConstExprNode& int_expr) {
-  std::cout << indenter_.Indent() << int_expr.val_ << ": "
+  std::cout << indenter_.Indent() << int_expr.val << ": "
             << ExprTypeToCString(int_expr.type) << std::endl;
 }
 
@@ -82,8 +82,8 @@ void AstDumper::Visit(const BinaryExprNode& bin_expr) {
   std::cout << indenter_.Indent() << '(' << OpGetter{}.OpOf(bin_expr)
             << std::endl;
   indenter_.IncreaseLevel();
-  bin_expr.lhs_->Accept(*this);
-  bin_expr.rhs_->Accept(*this);
+  bin_expr.lhs->Accept(*this);
+  bin_expr.rhs->Accept(*this);
   indenter_.DecreaseLevel();
   std::cout << indenter_.Indent() << ')' << ": "
             << ExprTypeToCString(bin_expr.type) << std::endl;
@@ -114,12 +114,12 @@ DISPATCH_TO_VISIT_BINARY_EXPR(NotEqualToExprNode);
 void AstDumper::Visit(const SimpleAssignmentExprNode& assign_expr) {
   std::cout << indenter_.Indent() << '(' << '=' << std::endl;
   indenter_.IncreaseLevel();
-  std::cout << indenter_.Indent() << assign_expr.id_ << ": "
+  std::cout << indenter_.Indent() << assign_expr.id << ": "
             << ExprTypeToCString(assign_expr.type) << std::endl;
-  assign_expr.expr_->Accept(*this);
+  assign_expr.expr->Accept(*this);
   indenter_.DecreaseLevel();
   std::cout << indenter_.Indent() << ')' << ": "
-            << ExprTypeToCString(assign_expr.expr_->type) << std::endl;
+            << ExprTypeToCString(assign_expr.expr->type) << std::endl;
 }
 
 class OpGetter::OpGetterImpl : public NonModifyingVisitor {

--- a/src/qbe_ir_generator.cpp
+++ b/src/qbe_ir_generator.cpp
@@ -76,29 +76,29 @@ void QbeIrGenerator::Visit(const DeclNode& decl) {
   int id_num = NextLocalNum();
   output << PrefixSigil(id_num) << " =l alloc4 4" << std::endl;
 
-  if (decl.init_) {
-    decl.init_->Accept(*this);
+  if (decl.init) {
+    decl.init->Accept(*this);
     int init_num = num_recorder.NumOfPrevExpr();
     output << "storew " << PrefixSigil(init_num) << ", " << PrefixSigil(id_num)
            << std::endl;
   }
   // Set up the number of the id so we know were to load it back.
-  id_to_num[decl.id_] = id_num;
+  id_to_num[decl.id] = id_num;
 }
 
 void QbeIrGenerator::Visit(const BlockStmtNode& block) {
   output << "@start" << std::endl;
-  for (const auto& decl : block.decls_) {
+  for (const auto& decl : block.decls) {
     decl->Accept(*this);
   }
-  for (const auto& stmt : block.stmts_) {
+  for (const auto& stmt : block.stmts) {
     stmt->Accept(*this);
   }
 }
 
 void QbeIrGenerator::Visit(const ProgramNode& program) {
   output << "export function w $main() {" << std::endl;
-  program.block_->Accept(*this);
+  program.block->Accept(*this);
   output << "}";
 }
 
@@ -107,19 +107,19 @@ void QbeIrGenerator::Visit(const NullStmtNode&) {
 }
 
 void QbeIrGenerator::Visit(const ReturnStmtNode& ret_stmt) {
-  ret_stmt.expr_->Accept(*this);
+  ret_stmt.expr->Accept(*this);
   int ret_num = num_recorder.NumOfPrevExpr();
   output << " ret " << PrefixSigil(ret_num) << std::endl;
 }
 
 void QbeIrGenerator::Visit(const ExprStmtNode& expr_stmt) {
-  expr_stmt.expr_->Accept(*this);
+  expr_stmt.expr->Accept(*this);
 }
 
 void QbeIrGenerator::Visit(const IdExprNode& id_expr) {
   /// @brief Plays the role of a "pointer". Its value has to be loaded to
   /// the register before use.
-  int id_num = id_to_num.at(id_expr.id_);
+  int id_num = id_to_num.at(id_expr.id);
   int reg_num = NextLocalNum();
   output << PrefixSigil(reg_num) << " =w loadw " << PrefixSigil(id_num)
          << std::endl;
@@ -128,14 +128,14 @@ void QbeIrGenerator::Visit(const IdExprNode& id_expr) {
 
 void QbeIrGenerator::Visit(const IntConstExprNode& int_expr) {
   int num = NextLocalNum();
-  output << PrefixSigil(num) << " =w copy " << int_expr.val_ << std::endl;
+  output << PrefixSigil(num) << " =w copy " << int_expr.val << std::endl;
   num_recorder.Record(num);
 }
 
 void QbeIrGenerator::Visit(const BinaryExprNode& bin_expr) {
-  bin_expr.lhs_->Accept(*this);
+  bin_expr.lhs->Accept(*this);
   int left_num = num_recorder.NumOfPrevExpr();
-  bin_expr.rhs_->Accept(*this);
+  bin_expr.rhs->Accept(*this);
   int right_num = num_recorder.NumOfPrevExpr();
   int num = NextLocalNum();
   output << PrefixSigil(num) << " =w " << OpNameGetter{}.OpNameOf(bin_expr)
@@ -167,10 +167,10 @@ DISPATCH_TO_VISIT_BINARY_EXPR(NotEqualToExprNode);
 #undef DISPATCH_TO_VISIT_BINARY_EXPR
 
 void QbeIrGenerator::Visit(const SimpleAssignmentExprNode& assign_expr) {
-  assign_expr.expr_->Accept(*this);
+  assign_expr.expr->Accept(*this);
   int expr_num = num_recorder.NumOfPrevExpr();
   output << "storew " << PrefixSigil(expr_num) << ", "
-         << PrefixSigil(id_to_num.at(assign_expr.id_)) << std::endl;
+         << PrefixSigil(id_to_num.at(assign_expr.id)) << std::endl;
   num_recorder.Record(expr_num);
 }
 

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -3,36 +3,36 @@
 #include "ast.hpp"
 
 void TypeChecker::Visit(DeclNode& decl) {
-  if (decl.init_) {
-    decl.init_->Accept(*this);
-    if (decl.init_->type != decl.type_) {
-      // TODO: incompatible types when initializing type 'type_' using type
-      // 'init_->type'
+  if (decl.init) {
+    decl.init->Accept(*this);
+    if (decl.init->type != decl.type) {
+      // TODO: incompatible types when initializing type 'type' using type
+      // 'init->type'
     }
   }
 
-  if (env_.Probe(decl.id_)) {
-    // TODO: redefinition of 'id_'
+  if (env_.Probe(decl.id)) {
+    // TODO: redefinition of 'id'
   } else {
-    auto symbol = std::make_unique<SymbolEntry>(decl.id_);
-    symbol->expr_type = decl.type_;
+    auto symbol = std::make_unique<SymbolEntry>(decl.id);
+    symbol->expr_type = decl.type;
     env_.Add(std::move(symbol));
   }
 }
 
 void TypeChecker::Visit(BlockStmtNode& block) {
   env_.PushScope();
-  for (auto& decl : block.decls_) {
+  for (auto& decl : block.decls) {
     decl->Accept(*this);
   }
-  for (auto& stmt : block.stmts_) {
+  for (auto& stmt : block.stmts) {
     stmt->Accept(*this);
   }
   env_.PopScope();
 }
 
 void TypeChecker::Visit(ProgramNode& program) {
-  program.block_->Accept(*this);
+  program.block->Accept(*this);
 }
 
 void TypeChecker::Visit(NullStmtNode&) {
@@ -40,21 +40,21 @@ void TypeChecker::Visit(NullStmtNode&) {
 }
 
 void TypeChecker::Visit(ReturnStmtNode& ret_stmt) {
-  ret_stmt.expr_->Accept(*this);
-  if (ret_stmt.expr_->type != ExprType::kInt) {
+  ret_stmt.expr->Accept(*this);
+  if (ret_stmt.expr->type != ExprType::kInt) {
     // TODO: return value type does not match the function type
   }
 }
 
 void TypeChecker::Visit(ExprStmtNode& expr_stmt) {
-  expr_stmt.expr_->Accept(*this);
+  expr_stmt.expr->Accept(*this);
 }
 
 void TypeChecker::Visit(IdExprNode& id_expr) {
-  if (auto symbol = env_.LookUp(id_expr.id_)) {
+  if (auto symbol = env_.LookUp(id_expr.id)) {
     id_expr.type = symbol->expr_type;
   } else {
-    // TODO: 'id_' undeclared
+    // TODO: 'id' undeclared
   }
 }
 
@@ -63,12 +63,12 @@ void TypeChecker::Visit(IntConstExprNode& int_expr) {
 }
 
 void TypeChecker::Visit(BinaryExprNode& bin_expr) {
-  bin_expr.lhs_->Accept(*this);
-  bin_expr.rhs_->Accept(*this);
-  if (bin_expr.lhs_->type != bin_expr.rhs_->type) {
+  bin_expr.lhs->Accept(*this);
+  bin_expr.rhs->Accept(*this);
+  if (bin_expr.lhs->type != bin_expr.rhs->type) {
     // TODO: invalid operands to binary +
   } else {
-    bin_expr.type = bin_expr.lhs_->type;
+    bin_expr.type = bin_expr.lhs->type;
   }
 }
 
@@ -95,9 +95,9 @@ DISPATCH_TO_VISIT_BINARY_EXPR(NotEqualToExprNode);
 #undef DISPATCH_TO_VISIT_BINARY_EXPR
 
 void TypeChecker::Visit(SimpleAssignmentExprNode& assign_expr) {
-  assign_expr.expr_->Accept(*this);
-  if (auto symbol = env_.LookUp(assign_expr.id_)) {
-    if (assign_expr.expr_->type == symbol->expr_type) {
+  assign_expr.expr->Accept(*this);
+  if (auto symbol = env_.LookUp(assign_expr.id)) {
+    if (assign_expr.expr->type == symbol->expr_type) {
       // 6.5.16 Assignment operators
       // The type of an assignment expression is the type of the left
       // operand unless the left operand has qualified type, in which case it is
@@ -105,9 +105,9 @@ void TypeChecker::Visit(SimpleAssignmentExprNode& assign_expr) {
       assign_expr.type = symbol->expr_type;
     } else {
       // TODO: assigning to 'symbol->expr_type' from incompatible type
-      // 'expr_->type'
+      // 'expr->type'
     }
   } else {
-    // TODO: 'id_' undeclared
+    // TODO: 'id' undeclared
   }
 }


### PR DESCRIPTION
As discussed in issue #43, all AST nodes are meant to be pure data structures.
Additionally, in response to issue #39, suffixes have been removed.