### PR TITLE
Fix Clang warning and change C files to Cpp files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ YACC = bison
 # -d: generate header with default name
 YFLAGS = --verbose --debug -d
 
-# Note that lex.yy.c is excluded deliberately, as "lex.yy.c" is considered a
-# header file (it's included by "y.tab.c").
-OBJS := $(shell find . -name "*.cpp") y.tab.o
+# Note that lex.yy.cpp is excluded deliberately, as "lex.yy.cpp" is considered a
+# header file (it's included by "y.tab.cpp").
+OBJS := $(shell find . -name "*.cpp" ! -name "y.tab.cpp" ! -name "lex.yy.cpp" ) y.tab.o
 OBJS := $(OBJS:.cpp=.o)
 DEPS = $(OBJS:.o=.d)
 
@@ -25,11 +25,11 @@ test: $(TARGET)
 $(TARGET): $(OBJS)
 	$(CXX) $(CXXFLAGS) $(OBJS) -o $@
 
-lex.yy.c: lexer.l
+lex.yy.cpp: lexer.l
 	$(LEX) -o $@ $<
 
-y.tab.h: y.tab.c
-y.tab.c: parser.y lex.yy.c
+y.tab.hpp: y.tab.cpp
+y.tab.cpp: parser.y lex.yy.cpp
 	$(YACC) $(YFLAGS) $< -o $@
 
 #
@@ -38,10 +38,10 @@ y.tab.c: parser.y lex.yy.c
 # dependency explicit to enforce the ordering.
 #
 
-main.o: %.o: %.cpp y.tab.h
+main.o: %.o: %.cpp y.tab.hpp
 
 clean:
-	rm -rf *.s *.o lex.yy.c y.tab.c y.tab.h *.output *.ssa $(TARGET) $(OBJS) $(DEPS)
+	rm -rf *.s *.o lex.yy.* y.tab.* *.output *.ssa $(TARGET) $(OBJS) $(DEPS)
 	make -C test/ clean
 
 -include $(DEPS)

--- a/include/visitor.hpp
+++ b/include/visitor.hpp
@@ -6,31 +6,31 @@
 // Forward declarations to fix the acyclic problem with name only dependency.
 // NOTE: update the list every time a new kind of node is introduced.
 
-class AstNode;
-class StmtNode;
-class ExprNode;
-class DeclNode;
-class BlockStmtNode;
-class ProgramNode;
-class NullStmtNode;
-class ReturnStmtNode;
-class ExprStmtNode;
-class IdExprNode;
-class IntConstExprNode;
-class BinaryExprNode;
-class PlusExprNode;
-class SubExprNode;
-class MulExprNode;
-class DivExprNode;
-class ModExprNode;
-class GreaterThanExprNode;
-class GreaterThanOrEqualToExprNode;
-class LessThanExprNode;
-class LessThanOrEqualToExprNode;
-class EqualToExprNode;
-class NotEqualToExprNode;
-class AssignmentExprNode;
-class SimpleAssignmentExprNode;
+struct AstNode;
+struct StmtNode;
+struct ExprNode;
+struct DeclNode;
+struct BlockStmtNode;
+struct ProgramNode;
+struct NullStmtNode;
+struct ReturnStmtNode;
+struct ExprStmtNode;
+struct IdExprNode;
+struct IntConstExprNode;
+struct BinaryExprNode;
+struct PlusExprNode;
+struct SubExprNode;
+struct MulExprNode;
+struct DivExprNode;
+struct ModExprNode;
+struct GreaterThanExprNode;
+struct GreaterThanOrEqualToExprNode;
+struct LessThanExprNode;
+struct LessThanOrEqualToExprNode;
+struct EqualToExprNode;
+struct NotEqualToExprNode;
+struct AssignmentExprNode;
+struct SimpleAssignmentExprNode;
 
 /// @tparam is_modifying If `true`, `Visit()` takes a non-const reference of the
 /// visitable; otherwise, a const reference. Default to `false`.

--- a/lexer.l
+++ b/lexer.l
@@ -15,7 +15,7 @@
 #include <cstdlib>
 #include <iostream>
 
-#include "y.tab.h"
+#include "y.tab.hpp"
 
 // Use LINENO for the actual line number in the source code
 // yylineno has advanced to the next line when we reference it.

--- a/main.cpp
+++ b/main.cpp
@@ -10,7 +10,7 @@
 #include "scope.hpp"
 #include "type_checker.hpp"
 #include "util.hpp"
-#include "y.tab.h"
+#include "y.tab.hpp"
 
 /// @brief Where the generated code goes.
 std::ofstream output;

--- a/parser.y
+++ b/parser.y
@@ -6,7 +6,7 @@
 #include <vector>
 
 #include "ast.hpp"
-#include "lex.yy.c"
+#include "lex.yy.cpp"
 #include "type.hpp"
 
 extern std::unique_ptr<AstNode> program;


### PR DESCRIPTION
- Fix Clang mismatch warning

```
include/ast.hpp:14:1: warning: 'AstNode' defined as a struct here but previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
struct AstNode {
^
include/visitor.hpp:9:1: note: did you mean struct here?
class AstNode;
^~~~~
struct
```

- Use cpp files instead of c files as suggested by Clang