### PR TITLE
Run tests with g++ and clang++

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
           scripts/check-format.sh
   test:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        cxx: [g++, clang++]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
@@ -29,4 +32,4 @@ jobs:
       - name: Install Turnt
         run: pip install turnt
       - name: Run tests
-        run: make test
+        run: make test CXX=${{ matrix.cxx }}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TARGET := vitaminc
 CXX := g++
 CC = $(CXX)
-CXXFLAGS = -g3 -std=c++14 -Wall -MMD -Iinclude
+CXXFLAGS = -g3 -std=c++14 -Wall -MMD -Iinclude -Werror
 CFLAGS = $(CXXFLAGS)
 LEX = lex
 # C++ features are used, yacc doesn't suffice


### PR DESCRIPTION
These two mainstream compilers may discover warnings that the other does not catch (an example in #47), so we'd like to run tests with both.

> [!note]
> I prefer to add the `-Werror` flag only when running tests in our CI environment.
This way, we don't have to fix all warnings during development at the first moment.
However, it appears that we cannot append _Makefile_ variables via the command line, as the [`override` directive](https://www.gnu.org/software/make/manual/html_node/Override-Directive.html) doesn't achieve what I have in mind.