### PR TITLE
Remove test target from all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ DEPS = $(OBJS:.o=.d)
 
 .PHONY: all clean test
 
-all: $(TARGET) test
+all: $(TARGET)
 
 test: $(TARGET)
 	make -C test/


### PR DESCRIPTION
Since we have started to have more test cases, each build will take longer with default test target.
Thus, it would be better to remove test from default targets.