### PR TITLE
Enable parallel test option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,13 @@ LEX = lex
 YACC = bison
 # -d: generate header with default name
 YFLAGS = --verbose --debug -d
+# Check if -j multiple jobs is configured.
+PARALLEL = false
+ifneq (,$(findstring j,$(MAKEFLAGS)))
+	PARALLEL := true
+endif
+# Export variable to be visible for test/Makefile.
+export PARALLEL
 
 # Note that lex.yy.cpp is excluded deliberately, as "lex.yy.cpp" is considered a
 # header file (it's included by "y.tab.cpp").
@@ -20,7 +27,9 @@ DEPS = $(OBJS:.o=.d)
 all: $(TARGET)
 
 test: $(TARGET)
-	make -C test/
+	# Flags are omitted to prevent passing the -j option since Turnt, our testing tool,
+	# has its own mechanism for parallel builds.
+	cd test/ && $(MAKE) test MAKEFLAGS=
 
 $(TARGET): $(OBJS)
 	$(CXX) $(CXXFLAGS) $(OBJS) -o $@
@@ -42,6 +51,6 @@ main.o: %.o: %.cpp y.tab.hpp
 
 clean:
 	rm -rf *.s *.o lex.yy.* y.tab.* *.output *.ssa $(TARGET) $(OBJS) $(DEPS)
-	make -C test/ clean
+	cd test/ && $(MAKE) clean
 
 -include $(DEPS)

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,7 +1,12 @@
+TURNTFLAGS = --diff
+ifeq (true, $(PARALLEL))
+	TURNTFLAGS += -j
+endif
+
 .PHONY: test clean
 
 test:
-	turnt **/*.c --diff
+	turnt **/*.c $(TURNTFLAGS)
 
 clean:
 	rm -f *.s **/*.s *.o **/*.o *.ssa **/*.ssa

--- a/test/codegen/turnt.toml
+++ b/test/codegen/turnt.toml
@@ -1,2 +1,2 @@
-command = "../../vitaminc -o test.ssa < {filename} && qbe -o out.s test.ssa && cc out.s -o a.o && ./a.o; echo $?"
+command = "../../vitaminc -o {filename}.ssa < {filename} && qbe -o {filename}.s {filename}.ssa && cc {filename}.s -o {filename}.o && ./{filename}.o; echo $?"
 output.exp = "-"


### PR DESCRIPTION
Whenever users pass the `-j` flag with make, this setting will also enable parallel testing with turnt. For example:

```
make test -j8
```

Also, we don't want to pass `-j` to our sub-make since we only need `turnt` to execute in parallel.