### PR TITLE
Merge expression statement

### DIFF
--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -101,11 +101,6 @@ struct ProgramNode : public AstNode {
   std::unique_ptr<BlockStmtNode> block;
 };
 
-struct NullStmtNode : public StmtNode {
-  virtual void Accept(NonModifyingVisitor&) const override;
-  virtual void Accept(ModifyingVisitor&) override;
-};
-
 struct IfStmtNode : public StmtNode {
   IfStmtNode(std::unique_ptr<ExprNode> expr, std::unique_ptr<StmtNode> then,
              std::unique_ptr<StmtNode> or_else = {})
@@ -175,7 +170,7 @@ struct ExprStmtNode : public StmtNode {
   std::unique_ptr<ExprNode> expr;
 };
 
-/// @note Only appears in for statement's expressions.
+/// @note Only appears in for statement's expressions and null statement.
 struct NullExprNode : public ExprNode {
   virtual void Accept(NonModifyingVisitor&) const override;
   virtual void Accept(ModifyingVisitor&) override;

--- a/include/ast_dumper.hpp
+++ b/include/ast_dumper.hpp
@@ -11,7 +11,6 @@ class AstDumper : public NonModifyingVisitor {
   void Visit(const DeclNode&) override;
   void Visit(const BlockStmtNode&) override;
   void Visit(const ProgramNode&) override;
-  void Visit(const NullStmtNode&) override;
   void Visit(const IfStmtNode&) override;
   void Visit(const WhileStmtNode&) override;
   void Visit(const ForStmtNode&) override;

--- a/include/qbe_ir_generator.hpp
+++ b/include/qbe_ir_generator.hpp
@@ -9,7 +9,6 @@ class QbeIrGenerator : public NonModifyingVisitor {
   void Visit(const DeclNode&) override;
   void Visit(const BlockStmtNode&) override;
   void Visit(const ProgramNode&) override;
-  void Visit(const NullStmtNode&) override;
   void Visit(const IfStmtNode&) override;
   void Visit(const WhileStmtNode&) override;
   void Visit(const ForStmtNode&) override;

--- a/include/type_checker.hpp
+++ b/include/type_checker.hpp
@@ -14,7 +14,6 @@ class TypeChecker : public ModifyingVisitor {
   void Visit(DeclNode&) override;
   void Visit(BlockStmtNode&) override;
   void Visit(ProgramNode&) override;
-  void Visit(NullStmtNode&) override;
   void Visit(IfStmtNode&) override;
   void Visit(WhileStmtNode&) override;
   void Visit(ForStmtNode&) override;

--- a/include/visitor.hpp
+++ b/include/visitor.hpp
@@ -13,7 +13,6 @@ struct DeclNode;
 struct LoopInitNode;
 struct BlockStmtNode;
 struct ProgramNode;
-struct NullStmtNode;
 struct IfStmtNode;
 struct WhileStmtNode;
 struct ForStmtNode;
@@ -60,7 +59,6 @@ class Visitor {
   virtual void Visit(CondMut<LoopInitNode>&){};
   virtual void Visit(CondMut<BlockStmtNode>&){};
   virtual void Visit(CondMut<ProgramNode>&){};
-  virtual void Visit(CondMut<NullStmtNode>&){};
   virtual void Visit(CondMut<IfStmtNode>&){};
   virtual void Visit(CondMut<WhileStmtNode>&){};
   virtual void Visit(CondMut<ForStmtNode>&){};

--- a/parser.y
+++ b/parser.y
@@ -127,9 +127,8 @@ stmts: stmts stmt {
   | epsilon { $$ = std::vector<std::unique_ptr<StmtNode>>{}; }
   ;
 
-stmt: ';' { $$ = std::make_unique<NullStmtNode>(); }
+stmt: expr_opt ';' { $$ = std::make_unique<ExprStmtNode>($1); }
     | RETURN expr ';' { $$ = std::make_unique<ReturnStmtNode>($2); }
-    | expr ';' { $$ = std::make_unique<ExprStmtNode>($1); }
     | block { $$ = $1; }
     | IF '(' expr ')' stmt %prec IF_WITHOUT_ELSE { $$ = std::make_unique<IfStmtNode>($3, $5); }
     | IF '(' expr ')' stmt ELSE stmt { $$ = std::make_unique<IfStmtNode>($3, $5, $7); }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -64,14 +64,6 @@ void ProgramNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
-void NullStmtNode::Accept(NonModifyingVisitor& v) const {
-  v.Visit(*this);
-}
-
-void NullStmtNode::Accept(ModifyingVisitor& v) {
-  v.Visit(*this);
-}
-
 void IfStmtNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }

--- a/src/ast_dumper.cpp
+++ b/src/ast_dumper.cpp
@@ -61,10 +61,6 @@ void AstDumper::Visit(const ProgramNode& program) {
   program.block->Accept(*this);
 }
 
-void AstDumper::Visit(const NullStmtNode& stmt) {
-  std::cout << indenter_.Indent() << "()" << std::endl;
-}
-
 void AstDumper::Visit(const IfStmtNode& if_stmt) {
   std::cout << indenter_.Indent() << "(if" << std::endl;
   indenter_.IncreaseLevel();

--- a/src/qbe_ir_generator.cpp
+++ b/src/qbe_ir_generator.cpp
@@ -118,10 +118,6 @@ void QbeIrGenerator::Visit(const ProgramNode& program) {
   output << "}";
 }
 
-void QbeIrGenerator::Visit(const NullStmtNode&) {
-  /* do nothing */
-}
-
 void QbeIrGenerator::Visit(const IfStmtNode& if_stmt) {
   if_stmt.predicate->Accept(*this);
   int predicate_num = num_recorder.NumOfPrevExpr();

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -46,10 +46,6 @@ void TypeChecker::Visit(ProgramNode& program) {
   program.block->Accept(*this);
 }
 
-void TypeChecker::Visit(NullStmtNode&) {
-  /* do nothing */
-}
-
 void TypeChecker::Visit(IfStmtNode& if_stmt) {
   if_stmt.predicate->Accept(*this);
   if_stmt.then->Accept(*this);


### PR DESCRIPTION
Since we have an `expr_opt` non terminal node, we can merge `NullStmtNode` and `ExprStmtNode` into one.

```
6.8.3 Expression and null statements
Syntax
expression-statement:
  expressionopt ;
```