### PR TITLE
Install fmt library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
         run: scripts/install-qbe.sh
       - name: Install cxxopts
         run: scripts/install-cxxopts.sh
+      - name: Install fmt
+        run: scripts/install-fmt.sh
       - name: Install Turnt
         run: pip install turnt
       - name: Run tests

--- a/scripts/install-fmt.sh
+++ b/scripts/install-fmt.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+
+# number of jobs to run
+NPROCS=1
+# Find available processor numbers based on different OS.
+OS="$(uname -s)"
+case $OS in
+  'Linux')
+    NPROCS="$(grep -c ^processor /proc/cpuinfo)"
+    ;;
+  'Darwin')
+    NPROCS="$(sysctl -n hw.ncpu)"
+    ;;
+esac
+
+wget https://github.com/fmtlib/fmt/archive/refs/tags/10.1.1.tar.gz -O - | tar zxf - &&
+  cd fmt-10.1.1/ &&
+  mkdir build/ &&
+  cmake -B build/ . &&
+  sudo make -j"${NPROCS}" -C build/ install &&
+  cd .. &&
+  rm -rf fmt-10.1.1/


### PR DESCRIPTION
The purpose of this PR is to install fmt headers, so that we can utilize format strings for our output.

- Initial build time for `fmt` is `3m 18s`. Build time `1m 27s` with `-j` flag

Currently, only jobs can be run in parallel for Github workflows, and steps parallel support is still TBD[1]. 😢 

[1] https://github.com/orgs/community/discussions/14484