### PR TITLE
Remove the library folder without prompting

### DIFF
--- a/scripts/install-cxxopts.sh
+++ b/scripts/install-cxxopts.sh
@@ -6,4 +6,4 @@ wget https://github.com/jarro2783/cxxopts/archive/refs/tags/v3.1.1.tar.gz -O - |
   cmake -B build/ . &&
   sudo make -C build/ install &&
   cd .. &&
-  rm -r cxxopts-3.1.1/
+  rm -rf cxxopts-3.1.1/

--- a/scripts/install-qbe.sh
+++ b/scripts/install-qbe.sh
@@ -5,4 +5,4 @@ wget https://c9x.me/compile/release/qbe-1.1.tar.xz -O - | tar Jxf - &&
   make &&
   sudo make install &&
   cd .. &&
-  rm -r qbe-1.1/
+  rm -rf qbe-1.1/


### PR DESCRIPTION
The compiled libraries are read-only (write-protected); therefore, even though we have the necessary permissions to remove the build folder, `rm` prompts for confirmation.
To prevent this interaction when running the script, we include the `-f` flag.
