### PR TITLE
Refactor code generation with fmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ test: $(TARGET)
 	cd test/ && $(MAKE) test MAKEFLAGS=
 
 $(TARGET): $(OBJS)
-	$(CXX) $(CXXFLAGS) $(OBJS) -o $@
+	# Link fmt library after all object files, or else it will throw errors.
+	$(CXX) $(CXXFLAGS) $(OBJS) -lfmt -o $@
 
 lex.yy.cpp: lexer.l
 	$(LEX) -o $@ $<

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,0 +1,2 @@
+-I./include
+-I/usr/local/include


### PR DESCRIPTION
- Utilize fmt to generate *.ssa file with indent.
- Link fmt library

The following is the generated output:

```
# for_stmt.ssa
export function w $main() {
@start
        %.1 =l alloc4 4
        %.2 =w copy 0
        storew %.2, %.1
        %.3 =l alloc4 4
        # loop init
        %.4 =w copy 0
        storew %.4, %.3
@pred.1
        %.5 =w loadw %.3
        %.6 =w copy 5
        %.7 =w csltw %.5, %.6
        jnz %.7, @loop_body.1, @end.1
@loop_body.1
        %.8 =w loadw %.1
        %.9 =w copy 1
        %.10 =w add %.8, %.9
        storew %.10, %.1
        %.11 =w loadw %.3
        %.12 =w copy 1
        %.13 =w add %.11, %.12
        storew %.13, %.3
        jmp @pred.1
@end.1
        %.14 =w copy 0
        ret %.14
}
```

Looks better than before! 😄 