### PR TITLE
Resolve include dependency for lex.yy.cpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,7 @@ endif
 # Export variable to be visible for test/Makefile.
 export PARALLEL
 
-# Note that lex.yy.cpp is excluded deliberately, as "lex.yy.cpp" is considered a
-# header file (it's included by "y.tab.cpp").
-OBJS := $(shell find . -name "*.cpp" ! -name "y.tab.cpp" ! -name "lex.yy.cpp" ) y.tab.o
+OBJS := $(shell find . -name "*.cpp") lex.yy.o y.tab.o
 OBJS := $(OBJS:.cpp=.o)
 DEPS = $(OBJS:.o=.d)
 
@@ -34,11 +32,11 @@ test: $(TARGET)
 $(TARGET): $(OBJS)
 	$(CXX) $(CXXFLAGS) $(OBJS) -o $@
 
-lex.yy.cpp: lexer.l
+lex.yy.cpp: lexer.l y.tab.hpp
 	$(LEX) -o $@ $<
 
 y.tab.hpp: y.tab.cpp
-y.tab.cpp: parser.y lex.yy.cpp
+y.tab.cpp: parser.y
 	$(YACC) $(YFLAGS) $< -o $@
 
 #

--- a/parser.y
+++ b/parser.y
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "ast.hpp"
-#include "lex.yy.cpp"
 #include "type.hpp"
 
 extern std::unique_ptr<AstNode> program;
@@ -20,6 +19,11 @@ extern std::unique_ptr<AstNode> program;
   #include <vector>
 
   #include "ast.hpp"
+}
+
+// Placed after the usual contents of the parser header file.
+%code {
+  extern yy::parser::symbol_type yylex();
 }
 
 %skeleton "lalr1.cc"


### PR DESCRIPTION
Previously, we encountered issues due to the lack of forward declaration for the lexing function `yylex`. Consequently, we resorted to including lex.yy.cpp directly in parser.y to access it. The initial problem stemmed from our inability to insert it into the correct position within yy.tab.hpp. Recently, I found that the `%code` directive is aptly suited for addressing this issue.
The current dependency is now one-way, with only lex.yy.cpp depending on y.tab.hpp. Modifications have been made to the Makefile to align with this adjustment.

For more information, refer to:
https://www.gnu.org/software/bison/manual/html_node/_0025code-Summary.html#index-_0025code-5