### PR TITLE
Lint with clang tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,58 @@
+# Here is an explanation for why some of the checks are disabled:
+#
+# -modernize-use-trailing-return-type:
+#   Most of the times, trailing return types provide no benefit. The additional "auto" and "->" are just noise.
+#
+# -modernize-use-nodiscard:
+#   The leading [[nodiscard]] attribute adds noise to the code when reading it and may not provide considerable benefits.
+
+# Warnings are easily be overlooked when they are not treated as errors.
+WarningsAsErrors: "*"
+
+Checks: >
+  -*,
+  bugprone-*,
+  performance-*,
+  clang-analyzer-*,
+  cppcoreguidelines-*,
+  modernize-*,
+  -modernize-use-trailing-return-type,
+  -modernize-use-nodiscard,
+  readability-braces-around-statements,
+  readability-function-size,
+  readability-identifier-naming,
+  readability-inconsistent-declaration-parameter-name,
+  readability-isolate-declaration,
+  readability-magic-numbers
+  readability-misleading-indentation,
+  readability-non-const-parameter,
+  readability-redundant-control-flow,
+  readability-redundant-preprocessor,
+  readability-simplify-boolean-expr,
+
+CheckOptions:
+  - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }
+  - { key: readability-identifier-naming.ClassCase,              value: CamelCase  }
+  - { key: readability-identifier-naming.StructCase,             value: CamelCase  }
+  - { key: readability-identifier-naming.TemplateParameterCase,  value: CamelCase  }
+  - { key: readability-identifier-naming.FunctionCase,           value: CamelCase  }
+  - { key: readability-identifier-naming.VariableCase,           value: lower_case }
+  - { key: readability-identifier-naming.ClassMemberCase,        value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberSuffix,    value: _          }
+  - { key: readability-identifier-naming.ProtectedMemberSuffix,  value: _          }
+  - { key: readability-identifier-naming.ClassMethodCase,        value: CamelCase }
+  - { key: readability-identifier-naming.PrivateMethodSuffix,    value: _          }
+  - { key: readability-identifier-naming.ProtectedMethodSuffix,  value: _          }
+  - { key: readability-identifier-naming.EnumConstantCase,         value: CamelCase }
+  - { key: readability-identifier-naming.EnumConstantPrefix,       value: k         }
+  - { key: readability-identifier-naming.ConstexprVariableCase,    value: CamelCase }
+  - { key: readability-identifier-naming.ConstexprVariablePrefix,  value: k         }
+  - { key: readability-identifier-naming.GlobalConstantCase,       value: CamelCase }
+  - { key: readability-identifier-naming.GlobalConstantPrefix,     value: k         }
+  - { key: readability-identifier-naming.MemberConstantCase,       value: CamelCase }
+  - { key: readability-identifier-naming.MemberConstantPrefix,     value: k         }
+  - { key: readability-identifier-naming.StaticConstantCase,       value: CamelCase }
+  - { key: readability-identifier-naming.StaticConstantPrefix,     value: k         }
+  - { key: readability-implicit-bool-conversion.AllowIntegerConditions,  value: 1   }
+  - { key: readability-implicit-bool-conversion.AllowPointerConditions,  value: 1   }
+  - { key: readability-function-cognitive-complexity.IgnoreMacros,  value: 1   }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,30 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          # Fetch all history for proper diffing.
+          fetch-depth: 0
       - name: coding convention
         run: |
           sudo apt-get install -q -y clang-format
           scripts/check-format.sh
+      - name: Install cxxopts
+        run: scripts/install-cxxopts.sh
+      - name: Install fmt
+        run: scripts/install-fmt.sh
+      - name: Install bear
+        run: sudo apt-get install -q -y bear
+      - name: Install clang-tidy
+        run: |
+          sudo add-apt-repository -y 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main'
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get install -q -y clang-tidy-18
+      - name: static checks
+        run: |
+          export CLANG_TIDY_DIFF=clang-tidy-diff-18.py
+          scripts/check-tidy.sh
+
   test:
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,22 @@ on:
       - main
 
 jobs:
-  lint:
+  format:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: coding convention
+        run: |
+          sudo apt-get install -q -y clang-format
+          scripts/check-format.sh
+
+  tidy:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:
           # Fetch all history for proper diffing.
           fetch-depth: 0
-      - name: coding convention
-        run: |
-          sudo apt-get install -q -y clang-format
-          scripts/check-format.sh
       - name: Install cxxopts
         run: scripts/install-cxxopts.sh
       - name: Install fmt

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ venv.bak/
 
 # VS Code configs
 .vscode
+
+# Compilation database
+compile_commands.json

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,14 @@ endif
 # Export variable to be visible for test/Makefile.
 export PARALLEL
 
-OBJS := $(shell find . -name "*.cpp") lex.yy.o y.tab.o
+SRC := $(shell find -name "*.cpp")
+INC := $(shell find -name "*.hpp")
+
+OBJS := $(SRC) lex.yy.o y.tab.o
 OBJS := $(OBJS:.cpp=.o)
 DEPS = $(OBJS:.o=.d)
 
-.PHONY: all clean test
+.PHONY: all clean test tidy
 
 all: $(TARGET)
 
@@ -47,6 +50,9 @@ y.tab.cpp: parser.y
 #
 
 main.o: %.o: %.cpp y.tab.hpp
+
+tidy:
+	clang-tidy $(CLANG_TIDY_FLAGS) -p . $(SRC) $(INC) -- $(CXXFLAGS)
 
 clean:
 	rm -rf *.s *.o lex.yy.* y.tab.* *.output *.ssa $(TARGET) $(OBJS) $(DEPS)

--- a/scripts/check-tidy.sh
+++ b/scripts/check-tidy.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+
+#
+# Runs clang-tidy on the diff between main and HEAD.
+# Note: This script is intended to be run in CI.
+#
+
+set -eu
+
+if [ -z "${GITHUB_ACTIONS+x}" ]; then
+  echo "error: this script is intended to be run in CI"
+  exit 1
+fi
+
+CLANG_TIDY_DIFF=${CLANG_TIDY_DIFF:-clang-tidy-diff.py}
+
+command -v bear >/dev/null 2>&1 || (
+  echo "error: bear is required to generate compile_commands.json; see https://github.com/rizsotto/Bear"
+  exit 1
+)
+
+# Run a clean build to generate compile_commands.json.
+make clean
+bear -- make
+git fetch origin "${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
+git diff -U0 "origin/${GITHUB_BASE_REF}" | ${CLANG_TIDY_DIFF} -p1


### PR DESCRIPTION
# What's changed?

Incorporated the static analyzer "clang-tidy" into our project to improve code quality.

- Added a make target `tidy` to perform tidy checks on the entire project. The compilation database `compile_commands.json` is not required for this target as the Makefile already contains the necessary commands.
- Introduced a CI job to conduct tidy checks on the difference between _main_ (`GITHUB_BASE_REF`) and _HEAD_. We utilize [Bear](https://github.com/rizsotto/Bear) to generate the compilation database.

Additionally, a script is added for CI execution. This script is not intended for local user execution due to the following reasons:

1. `clang-tidy-diff` supports exit with a failure code when there are errors from version 17 or 18 onward. (The exact version is uncertain. For more details, please refer to https://github.com/llvm/llvm-project/issues/65000.)
2. `bear` has different command line interfaces between version <= 2.4.x and onward. (For more details, please refer to [Bear's documentation](https://github.com/rizsotto/Bear?tab=readme-ov-file#how-to-use).)

The script may not function properly if any of these issues arise. In the CI environment, we ensure that the versions of these dependencies are up-to-date. Specifically, the version of `clang-tidy-diff` is specified as `18`, and the version of Bear on Ubuntu 22.04 is 3.0.x.
 
# How to test?

I pushed a testing commit which violates the naming rule to fail the CI, and it did fail as expected.

Resolves: #71 