### PR TITLE
Resolve linting errors reported by clang tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -53,6 +53,7 @@ CheckOptions:
   - { key: readability-identifier-naming.MemberConstantPrefix,     value: k         }
   - { key: readability-identifier-naming.StaticConstantCase,       value: CamelCase }
   - { key: readability-identifier-naming.StaticConstantPrefix,     value: k         }
+  - { key: readability-identifier-naming.ValueTemplateParameterCase, value: lower_case }
   - { key: readability-implicit-bool-conversion.AllowIntegerConditions,  value: 1   }
   - { key: readability-implicit-bool-conversion.AllowPointerConditions,  value: 1   }
   - { key: readability-function-cognitive-complexity.IgnoreMacros,  value: 1   }

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,9 @@
 #
 # -modernize-use-nodiscard:
 #   The leading [[nodiscard]] attribute adds noise to the code when reading it and may not provide considerable benefits.
+#
+# -cppcoreguidelines-explicit-virtual-functions:
+#   It's an alias of "modernize-use-override".
 
 # Warnings are easily be overlooked when they are not treated as errors.
 WarningsAsErrors: "*"
@@ -15,6 +18,7 @@ Checks: >
   performance-*,
   clang-analyzer-*,
   cppcoreguidelines-*,
+  -cppcoreguidelines-explicit-virtual-functions,
   modernize-*,
   -modernize-use-trailing-return-type,
   -modernize-use-nodiscard,

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,10 @@ y.tab.cpp: parser.y
 
 main.o: %.o: %.cpp y.tab.hpp
 
-tidy:
+# Since y.tab.hpp is included by the source files, it must exist;
+# otherwise, a clang-diagnostic-error will be raised.
+
+tidy: y.tab.hpp
 	$(CLANG_TIDY) $(CLANG_TIDY_FLAGS) -p . $(SRC) $(INC) -- $(CXXFLAGS)
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,9 @@ endif
 # Export variable to be visible for test/Makefile.
 export PARALLEL
 
-SRC := $(shell find -name "*.cpp")
-INC := $(shell find -name "*.hpp")
+# The Flex or Bison-generated files are not included.
+SRC := $(shell find src/ -name "*.cpp") main.cpp
+INC := $(shell find include/ -name "*.hpp")
 
 OBJS := $(SRC) lex.yy.o y.tab.o
 OBJS := $(OBJS:.cpp=.o)

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -54,9 +54,9 @@ struct ExprNode : public AstNode {
 };
 
 struct DeclNode : public AstNode {
-  DeclNode(const std::string& id, ExprType decl_type,
+  DeclNode(std::string id, ExprType decl_type,
            std::unique_ptr<ExprNode> init = {})
-      : id{id}, type{decl_type}, init{std::move(init)} {}
+      : id{std::move(id)}, type{decl_type}, init{std::move(init)} {}
 
   void Accept(NonModifyingVisitor&) const override;
   void Accept(ModifyingVisitor&) override;
@@ -192,7 +192,7 @@ struct NullExprNode : public ExprNode {
 };
 
 struct IdExprNode : public ExprNode {
-  IdExprNode(const std::string& id) : id{id} {}
+  IdExprNode(std::string id) : id{std::move(id)} {}
 
   void Accept(NonModifyingVisitor&) const override;
   void Accept(ModifyingVisitor&) override;

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -161,14 +161,14 @@ struct ReturnStmtNode : public StmtNode {
 };
 
 struct BreakStmtNode : public StmtNode {
-  BreakStmtNode() {}
+  BreakStmtNode() = default;
 
   void Accept(NonModifyingVisitor&) const override;
   void Accept(ModifyingVisitor&) override;
 };
 
 struct ContinueStmtNode : public StmtNode {
-  ContinueStmtNode() {}
+  ContinueStmtNode() = default;
 
   void Accept(NonModifyingVisitor&) const override;
   void Accept(ModifyingVisitor&) override;

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -36,21 +36,21 @@ struct AstNode {
 
 /// @note This is an abstract class.
 struct StmtNode : public AstNode {
-  virtual void Accept(NonModifyingVisitor&) const override;
-  virtual void Accept(ModifyingVisitor&) override;
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
 
   /// @note To make the class abstract.
-  virtual ~StmtNode() = 0;
+  ~StmtNode() override = 0;
 };
 
 /// @note This is an abstract class.
 struct ExprNode : public AstNode {
   ExprType type = ExprType::kUnknown;
-  virtual void Accept(NonModifyingVisitor&) const override;
-  virtual void Accept(ModifyingVisitor&) override;
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
 
   /// @note To make the class abstract.
-  virtual ~ExprNode() = 0;
+  ~ExprNode() override = 0;
 };
 
 struct DeclNode : public AstNode {
@@ -58,8 +58,8 @@ struct DeclNode : public AstNode {
            std::unique_ptr<ExprNode> init = {})
       : id{id}, type{decl_type}, init{std::move(init)} {}
 
-  virtual void Accept(NonModifyingVisitor&) const override;
-  virtual void Accept(ModifyingVisitor&) override;
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
 
   std::string id;
   ExprType type;
@@ -72,8 +72,8 @@ struct LoopInitNode : public AstNode {
       std::variant<std::unique_ptr<DeclNode>, std::unique_ptr<ExprNode>> clause)
       : clause{std::move(clause)} {}
 
-  virtual void Accept(NonModifyingVisitor&) const override;
-  virtual void Accept(ModifyingVisitor&) override;
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
 
   std::variant<std::unique_ptr<DeclNode>, std::unique_ptr<ExprNode>> clause;
 };
@@ -84,8 +84,8 @@ struct BlockStmtNode : public StmtNode {
                 std::vector<std::unique_ptr<StmtNode>>&& stmts)
       : decls{std::move(decls)}, stmts{std::move(stmts)} {}
 
-  virtual void Accept(NonModifyingVisitor&) const override;
-  virtual void Accept(ModifyingVisitor&) override;
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
 
   std::vector<std::unique_ptr<DeclNode>> decls;
   std::vector<std::unique_ptr<StmtNode>> stmts;
@@ -96,8 +96,8 @@ struct ProgramNode : public AstNode {
   /// @note vector of move-only elements are move-only
   ProgramNode(std::unique_ptr<BlockStmtNode> block) : block{std::move(block)} {}
 
-  virtual void Accept(NonModifyingVisitor&) const override;
-  virtual void Accept(ModifyingVisitor&) override;
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
 
   std::unique_ptr<BlockStmtNode> block;
 };
@@ -109,8 +109,8 @@ struct IfStmtNode : public StmtNode {
         then{std::move(then)},
         or_else{std::move(or_else)} {}
 
-  virtual void Accept(NonModifyingVisitor&) const override;
-  virtual void Accept(ModifyingVisitor&) override;
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
 
   std::unique_ptr<ExprNode> predicate;
   std::unique_ptr<StmtNode> then;
@@ -124,8 +124,8 @@ struct WhileStmtNode : public StmtNode {
         loop_body{std::move(loop_body)},
         is_do_while{is_do_while} {}
 
-  virtual void Accept(NonModifyingVisitor&) const override;
-  virtual void Accept(ModifyingVisitor&) override;
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
 
   std::unique_ptr<ExprNode> predicate;
   std::unique_ptr<StmtNode> loop_body;
@@ -142,8 +142,8 @@ struct ForStmtNode : public StmtNode {
         step{std::move(step)},
         loop_body{std::move(loop_body)} {}
 
-  virtual void Accept(NonModifyingVisitor&) const override;
-  virtual void Accept(ModifyingVisitor&) override;
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
 
   std::unique_ptr<LoopInitNode> loop_init;
   std::unique_ptr<ExprNode> predicate;
@@ -154,8 +154,8 @@ struct ForStmtNode : public StmtNode {
 struct ReturnStmtNode : public StmtNode {
   ReturnStmtNode(std::unique_ptr<ExprNode> expr) : expr{std::move(expr)} {}
 
-  virtual void Accept(NonModifyingVisitor&) const override;
-  virtual void Accept(ModifyingVisitor&) override;
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
 
   std::unique_ptr<ExprNode> expr;
 };
@@ -163,15 +163,15 @@ struct ReturnStmtNode : public StmtNode {
 struct BreakStmtNode : public StmtNode {
   BreakStmtNode() {}
 
-  virtual void Accept(NonModifyingVisitor&) const override;
-  virtual void Accept(ModifyingVisitor&) override;
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
 };
 
 struct ContinueStmtNode : public StmtNode {
   ContinueStmtNode() {}
 
-  virtual void Accept(NonModifyingVisitor&) const override;
-  virtual void Accept(ModifyingVisitor&) override;
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
 };
 
 /// @note Any expression can be turned into a statement by adding a semicolon
@@ -179,23 +179,23 @@ struct ContinueStmtNode : public StmtNode {
 struct ExprStmtNode : public StmtNode {
   ExprStmtNode(std::unique_ptr<ExprNode> expr) : expr{std::move(expr)} {}
 
-  virtual void Accept(NonModifyingVisitor&) const override;
-  virtual void Accept(ModifyingVisitor&) override;
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
 
   std::unique_ptr<ExprNode> expr;
 };
 
 /// @note Only appears in for statement's expressions and null statement.
 struct NullExprNode : public ExprNode {
-  virtual void Accept(NonModifyingVisitor&) const override;
-  virtual void Accept(ModifyingVisitor&) override;
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
 };
 
 struct IdExprNode : public ExprNode {
   IdExprNode(const std::string& id) : id{id} {}
 
-  virtual void Accept(NonModifyingVisitor&) const override;
-  virtual void Accept(ModifyingVisitor&) override;
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
 
   std::string id;
 };
@@ -203,8 +203,8 @@ struct IdExprNode : public ExprNode {
 struct IntConstExprNode : public ExprNode {
   IntConstExprNode(int val) : val{val} {}
 
-  virtual void Accept(NonModifyingVisitor&) const override;
-  virtual void Accept(ModifyingVisitor&) override;
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
 
   int val;
 };
@@ -213,8 +213,8 @@ struct UnaryExprNode : public ExprNode {
   UnaryExprNode(UnaryOperator op, std::unique_ptr<ExprNode> operand)
       : op{op}, operand{std::move(operand)} {}
 
-  virtual void Accept(NonModifyingVisitor&) const override;
-  virtual void Accept(ModifyingVisitor&) override;
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
 
   UnaryOperator op;
   std::unique_ptr<ExprNode> operand;
@@ -225,8 +225,8 @@ struct BinaryExprNode : public ExprNode {
                  std::unique_ptr<ExprNode> rhs)
       : op{op}, lhs{std::move(lhs)}, rhs{std::move(rhs)} {}
 
-  virtual void Accept(NonModifyingVisitor&) const override;
-  virtual void Accept(ModifyingVisitor&) override;
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
 
   BinaryOperator op;
   std::unique_ptr<ExprNode> lhs;
@@ -235,19 +235,19 @@ struct BinaryExprNode : public ExprNode {
 
 /// @note This is an abstract class.
 struct AssignmentExprNode : public ExprNode {
-  virtual void Accept(NonModifyingVisitor&) const override;
-  virtual void Accept(ModifyingVisitor&) override;
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
 
   /// @note To make the class abstract.
-  virtual ~AssignmentExprNode() = 0;
+  ~AssignmentExprNode() override = 0;
 };
 
 struct SimpleAssignmentExprNode : public AssignmentExprNode {
   SimpleAssignmentExprNode(std::string id, std::unique_ptr<ExprNode> expr)
       : id{std::move(id)}, expr{std::move(expr)} {}
 
-  virtual void Accept(NonModifyingVisitor&) const override;
-  virtual void Accept(ModifyingVisitor&) override;
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
 
   std::string id;
   std::unique_ptr<ExprNode> expr;

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -34,6 +34,12 @@ struct AstNode {
   AstNode& operator=(AstNode&&) = delete;
 };
 
+// NOLINTBEGIN(cppcoreguidelines-special-member-functions):
+// Since the base class `AstNode` doesn't have a pure virtual destructor,
+// subclasses have to mark their destructors as pure virtual again to make the
+// class abstract. The destructor is then defined out-of-class using `=
+// default`; we do not actually define a custom destructor.
+
 /// @note This is an abstract class.
 struct StmtNode : public AstNode {
   void Accept(NonModifyingVisitor&) const override;
@@ -43,8 +49,11 @@ struct StmtNode : public AstNode {
   ~StmtNode() override = 0;
 };
 
+// NOLINTEND(cppcoreguidelines-special-member-functions)
+
 /// @note This is an abstract class.
-struct ExprNode : public AstNode {
+struct ExprNode  // NOLINT(cppcoreguidelines-special-member-functions)
+    : public AstNode {
   ExprType type = ExprType::kUnknown;
   void Accept(NonModifyingVisitor&) const override;
   void Accept(ModifyingVisitor&) override;
@@ -234,7 +243,8 @@ struct BinaryExprNode : public ExprNode {
 };
 
 /// @note This is an abstract class.
-struct AssignmentExprNode : public ExprNode {
+struct AssignmentExprNode  // NOLINT(cppcoreguidelines-special-member-functions)
+    : public ExprNode {
   void Accept(NonModifyingVisitor&) const override;
   void Accept(ModifyingVisitor&) override;
 

--- a/include/ast_dumper.hpp
+++ b/include/ast_dumper.hpp
@@ -25,10 +25,10 @@ class AstDumper : public NonModifyingVisitor {
   void Visit(const BinaryExprNode&) override;
   void Visit(const SimpleAssignmentExprNode&) override;
 
-  AstDumper(Indenter& indenter) : indenter_{indenter} {}
+  AstDumper(Indenter indenter) : indenter_{indenter} {}
 
  private:
-  Indenter& indenter_;
+  Indenter indenter_;
 };
 
 #endif  // AST_DUMPER_HPP_

--- a/include/operator.hpp
+++ b/include/operator.hpp
@@ -1,7 +1,9 @@
 #ifndef OPERATOR_HPP_
 #define OPERATOR_HPP_
 
-enum class BinaryOperator {
+#include <cstdint>
+
+enum class BinaryOperator : std::uint8_t {
   kAdd,
   kSub,
   kMul,
@@ -15,7 +17,7 @@ enum class BinaryOperator {
   kNeq,
 };
 
-enum class UnaryOperator {
+enum class UnaryOperator : std::uint8_t {
   kIncr,
   kDecr,
   kNeg,

--- a/include/qbe/sigil.hpp
+++ b/include/qbe/sigil.hpp
@@ -19,7 +19,9 @@ namespace qbe {
 class Sigil {
  public:
   /// @brief Returns the name.
-  std::string_view name() const noexcept {
+  std::string_view name()  // NOLINT(readability-identifier-naming): Accessors
+                           // may be named like variables.
+      const noexcept {
     return name_;
   }
 

--- a/include/qbe_ir_generator.hpp
+++ b/include/qbe_ir_generator.hpp
@@ -1,6 +1,11 @@
 #ifndef QBE_IR_GENERATOR_HPP_
 #define QBE_IR_GENERATOR_HPP_
 
+#include <fmt/core.h>
+
+#include <iosfwd>
+
+#include "ast.hpp"
 #include "visitor.hpp"
 
 class QbeIrGenerator : public NonModifyingVisitor {
@@ -22,6 +27,25 @@ class QbeIrGenerator : public NonModifyingVisitor {
   void Visit(const UnaryExprNode&) override;
   void Visit(const BinaryExprNode&) override;
   void Visit(const SimpleAssignmentExprNode&) override;
+
+  QbeIrGenerator(std::ostream& output) : output_{output} {}
+
+ private:
+  std::ostream& output_;
+
+  /// @brief Writes out the formatted string to `output`.
+  /// @note This is a convenience function to avoid having to pass `output`
+  /// everywhere.
+  template <typename... T>
+  void WriteOut_(
+      fmt::format_string<T...> format,
+      T&&... args) {  // NOLINT(cppcoreguidelines-missing-std-forward):
+                      // `make_format_args` takes rvalue references.
+    VWriteOut_(format, fmt::make_format_args(args...));
+  }
+
+  /// @note This function is not meant to be used directly.
+  void VWriteOut_(fmt::string_view format, fmt::format_args args);
 };
 
 #endif  // QBE_IR_GENERATOR_HPP_

--- a/include/symbol.hpp
+++ b/include/symbol.hpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "type.hpp"
 
@@ -11,7 +12,7 @@ struct SymbolEntry {
   std::string id;
   ExprType expr_type;
 
-  SymbolEntry(std::string id) : id{id} {}
+  SymbolEntry(std::string id) : id{std::move(id)} {}
 };
 
 class SymbolTable {

--- a/include/symbol.hpp
+++ b/include/symbol.hpp
@@ -10,7 +10,7 @@
 
 struct SymbolEntry {
   std::string id;
-  ExprType expr_type;
+  ExprType expr_type{ExprType::kUnknown};
 
   SymbolEntry(std::string id) : id{std::move(id)} {}
 };

--- a/include/type.hpp
+++ b/include/type.hpp
@@ -1,11 +1,12 @@
 #ifndef TYPE_HPP_
 #define TYPE_HPP_
 
+#include <cstdint>
 #include <string>
 
 /// @note C has a lots of primitive type. We might need to use classes to
 /// implement type coercion rules.
-enum class ExprType {
+enum class ExprType : std::uint8_t {
   kUnknown = 0,  // HACK: default initialized to 0 -> unknown
   kInt,
 };

--- a/include/util.hpp
+++ b/include/util.hpp
@@ -6,6 +6,11 @@
 
 class Indenter {
  public:
+  /// @brief A strong named type for the size of the indention.
+  enum SizePerLevel : std::size_t;
+  /// @brief A strong named type for the max level of indention.
+  enum MaxLevel : std::size_t;
+
   /// @return `size_per_level` * `level` number of `symbol`s.
   std::string Indent() const;
 
@@ -18,7 +23,8 @@ class Indenter {
   /// @param size_per_level The indention size. For example, if the size is `2`,
   /// each indention level adds 2 `symbol`s.
   /// @param max_level If equals to `0`, there is no limit.
-  Indenter(char symbol, std::size_t size_per_level, std::size_t max_level = 0)
+  Indenter(char symbol, SizePerLevel size_per_level,
+           MaxLevel max_level = MaxLevel{0})
       : symbol_{symbol},
         size_per_level_{size_per_level},
         max_level_{max_level} {}

--- a/include/visitor.hpp
+++ b/include/visitor.hpp
@@ -69,6 +69,14 @@ class Visitor {
   /// @note To make the class abstract. But still we have to provide an
   /// out-of-class definition for the destructor.
   virtual ~Visitor() = 0;
+  Visitor() = default;
+
+  // Delete copy/move operations to avoid slicing.
+
+  Visitor(const Visitor&) = delete;
+  Visitor& operator=(const Visitor&) = delete;
+  Visitor(Visitor&&) = delete;
+  Visitor& operator=(Visitor&&) = delete;
 };
 
 template <bool is_modifying>

--- a/main.cpp
+++ b/main.cpp
@@ -52,7 +52,8 @@ int main(int argc, char** argv) {
   TypeChecker type_checker{scopes};
   program->Accept(type_checker);
   if (args["dump"].as<bool>()) {
-    auto indenter = Indenter{' ', 2, 80};
+    const auto max_level = 80u;
+    auto indenter = Indenter{' ', 2, max_level};
     AstDumper ast_dumper{indenter};
     program->Accept(ast_dumper);
   }

--- a/main.cpp
+++ b/main.cpp
@@ -12,11 +12,6 @@
 #include "util.hpp"
 #include "y.tab.hpp"
 
-/// @brief Where the generated code goes.
-std::ofstream output;
-/// @brief The root node of the program.
-auto program = std::unique_ptr<AstNode>{};
-
 extern void yylex_destroy();  // NOLINT(readability-identifier-naming): extern
                               // from flex generated code.
 
@@ -39,8 +34,10 @@ int main(int argc, char** argv) {
     std::exit(0);
   }
 
-  output.open(args["output"].as<std::string>());
-  yy::parser parser{};
+  auto output = std::ofstream{args["output"].as<std::string>()};
+  /// @brief The root node of the program.
+  auto program = std::unique_ptr<AstNode>{};
+  yy::parser parser{program};
   int ret = parser.parse();
 
   yylex_destroy();
@@ -59,7 +56,7 @@ int main(int argc, char** argv) {
     AstDumper ast_dumper{Indenter{' ', 2, max_level}};
     program->Accept(ast_dumper);
   }
-  QbeIrGenerator code_generator{};
+  QbeIrGenerator code_generator{output};
   program->Accept(code_generator);
 
   output.close();

--- a/main.cpp
+++ b/main.cpp
@@ -32,7 +32,7 @@ int main(int argc, char** argv) {
 
   auto args = cmd_options.parse(argc, argv);
   if (args.count("help")) {
-    std::cerr << cmd_options.help() << std::endl;
+    std::cerr << cmd_options.help() << '\n';
     std::exit(0);
   }
 

--- a/main.cpp
+++ b/main.cpp
@@ -15,7 +15,11 @@
 extern void yylex_destroy();  // NOLINT(readability-identifier-naming): extern
                               // from flex generated code.
 
-int main(int argc, char** argv) {
+int main(  // NOLINT(bugprone-exception-escape): Using a big try-catch block to
+           // catch all exceptions isn't reasonable.
+    int argc, char** argv)
+
+{
   auto cmd_options = cxxopts::Options{
       argv[0],  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic):
                 // std::span is available in C++20.

--- a/main.cpp
+++ b/main.cpp
@@ -21,7 +21,10 @@ extern void yylex_destroy();  // NOLINT(readability-identifier-naming): extern
                               // from flex generated code.
 
 int main(int argc, char** argv) {
-  auto cmd_options = cxxopts::Options{argv[0], "A simple C compiler."};
+  auto cmd_options = cxxopts::Options{
+      argv[0],  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic):
+                // std::span is available in C++20.
+      "A simple C compiler."};
   // clang-format off
   cmd_options.add_options()
       ("o, output", "Write output to <file>", cxxopts::value<std::string>()->default_value("test.ssa"), "<file>")

--- a/main.cpp
+++ b/main.cpp
@@ -48,14 +48,14 @@ int main(int argc, char** argv) {
 
   // perform analyses and transformations on the ast
   auto scopes = ScopeStack{};
-  auto type_checker = TypeChecker{scopes};
+  TypeChecker type_checker{scopes};
   program->Accept(type_checker);
   if (args["dump"].as<bool>()) {
     auto indenter = Indenter{' ', 2, 80};
-    auto ast_dumper = AstDumper{indenter};
+    AstDumper ast_dumper{indenter};
     program->Accept(ast_dumper);
   }
-  auto code_generator = QbeIrGenerator{};
+  QbeIrGenerator code_generator{};
   program->Accept(code_generator);
 
   output.close();

--- a/main.cpp
+++ b/main.cpp
@@ -56,8 +56,7 @@ int main(int argc, char** argv) {
   program->Accept(type_checker);
   if (args["dump"].as<bool>()) {
     const auto max_level = 80u;
-    auto indenter = Indenter{' ', 2, max_level};
-    AstDumper ast_dumper{indenter};
+    AstDumper ast_dumper{Indenter{' ', 2, max_level}};
     program->Accept(ast_dumper);
   }
   QbeIrGenerator code_generator{};

--- a/main.cpp
+++ b/main.cpp
@@ -17,7 +17,8 @@ std::ofstream output;
 /// @brief The root node of the program.
 auto program = std::unique_ptr<AstNode>{};
 
-extern void yylex_destroy();
+extern void yylex_destroy();  // NOLINT(readability-identifier-naming): extern
+                              // from flex generated code.
 
 int main(int argc, char** argv) {
   auto cmd_options = cxxopts::Options{argv[0], "A simple C compiler."};

--- a/main.cpp
+++ b/main.cpp
@@ -53,7 +53,8 @@ int main(int argc, char** argv) {
   program->Accept(type_checker);
   if (args["dump"].as<bool>()) {
     const auto max_level = 80u;
-    AstDumper ast_dumper{Indenter{' ', 2, max_level}};
+    AstDumper ast_dumper{Indenter{' ', Indenter::SizePerLevel{2},
+                                  Indenter::MaxLevel{max_level}}};
     program->Accept(ast_dumper);
   }
   QbeIrGenerator code_generator{output};

--- a/parser.y
+++ b/parser.y
@@ -9,7 +9,6 @@
 #include "ast.hpp"
 #include "type.hpp"
 
-extern std::unique_ptr<AstNode> program;
 %}
 
 // Dependency code required for the value and location types;
@@ -30,6 +29,8 @@ extern std::unique_ptr<AstNode> program;
 %skeleton "lalr1.cc"
 %require "3.2"
 %language "c++"
+
+%parse-param {std::unique_ptr<AstNode>& program}
 
 // Use complete symbols (parser::symbol_type).
 %define api.token.constructor

--- a/src/ast_dumper.cpp
+++ b/src/ast_dumper.cpp
@@ -66,12 +66,12 @@ void AstDumper::Visit(const DeclNode& decl) {
   std::cout << indenter_.Indent() << '(' << decl.id << ": "
             << ExprTypeToString(decl.type);
   if (decl.init) {
-    std::cout << " =" << std::endl;
+    std::cout << " =" << '\n';
     indenter_.IncreaseLevel();
     decl.init->Accept(*this);
     indenter_.DecreaseLevel();
   }
-  std::cout << indenter_.Indent() << ')' << std::endl;
+  std::cout << indenter_.Indent() << ')' << '\n';
 }
 
 void AstDumper::Visit(const LoopInitNode& loop_init) {
@@ -96,64 +96,64 @@ void AstDumper::Visit(const ProgramNode& program) {
 }
 
 void AstDumper::Visit(const IfStmtNode& if_stmt) {
-  std::cout << indenter_.Indent() << "(if" << std::endl;
+  std::cout << indenter_.Indent() << "(if" << '\n';
   indenter_.IncreaseLevel();
   if_stmt.predicate->Accept(*this);
   if_stmt.then->Accept(*this);
   indenter_.DecreaseLevel();
-  std::cout << indenter_.Indent() << ')' << std::endl;
+  std::cout << indenter_.Indent() << ')' << '\n';
   if (if_stmt.or_else) {
-    std::cout << indenter_.Indent() << "(else" << std::endl;
+    std::cout << indenter_.Indent() << "(else" << '\n';
     indenter_.IncreaseLevel();
     if_stmt.or_else->Accept(*this);
     indenter_.DecreaseLevel();
-    std::cout << indenter_.Indent() << ')' << std::endl;
+    std::cout << indenter_.Indent() << ')' << '\n';
   }
 }
 
 void AstDumper::Visit(const WhileStmtNode& while_stmt) {
   if (while_stmt.is_do_while) {
-    std::cout << indenter_.Indent() << "(do" << std::endl;
+    std::cout << indenter_.Indent() << "(do" << '\n';
     indenter_.IncreaseLevel();
     while_stmt.loop_body->Accept(*this);
     indenter_.DecreaseLevel();
-    std::cout << indenter_.Indent() << ')' << std::endl;
+    std::cout << indenter_.Indent() << ')' << '\n';
   }
-  std::cout << indenter_.Indent() << "(while" << std::endl;
+  std::cout << indenter_.Indent() << "(while" << '\n';
   indenter_.IncreaseLevel();
   while_stmt.predicate->Accept(*this);
   if (!while_stmt.is_do_while) {
     while_stmt.loop_body->Accept(*this);
   }
   indenter_.DecreaseLevel();
-  std::cout << indenter_.Indent() << ')' << std::endl;
+  std::cout << indenter_.Indent() << ')' << '\n';
 }
 
 void AstDumper::Visit(const ForStmtNode& for_stmt) {
-  std::cout << indenter_.Indent() << "(for" << std::endl;
+  std::cout << indenter_.Indent() << "(for" << '\n';
   indenter_.IncreaseLevel();
   for_stmt.loop_init->Accept(*this);
   for_stmt.predicate->Accept(*this);
   for_stmt.step->Accept(*this);
   for_stmt.loop_body->Accept(*this);
   indenter_.DecreaseLevel();
-  std::cout << indenter_.Indent() << ')' << std::endl;
+  std::cout << indenter_.Indent() << ')' << '\n';
 }
 
 void AstDumper::Visit(const ReturnStmtNode& ret_stmt) {
-  std::cout << indenter_.Indent() << "(ret" << std::endl;
+  std::cout << indenter_.Indent() << "(ret" << '\n';
   indenter_.IncreaseLevel();
   ret_stmt.expr->Accept(*this);
   indenter_.DecreaseLevel();
-  std::cout << indenter_.Indent() << ')' << std::endl;
+  std::cout << indenter_.Indent() << ')' << '\n';
 }
 
 void AstDumper::Visit(const BreakStmtNode& break_stmt) {
-  std::cout << indenter_.Indent() << "(break)" << std::endl;
+  std::cout << indenter_.Indent() << "(break)" << '\n';
 }
 
 void AstDumper::Visit(const ContinueStmtNode& continue_stmt) {
-  std::cout << indenter_.Indent() << "(continue)" << std::endl;
+  std::cout << indenter_.Indent() << "(continue)" << '\n';
 }
 
 void AstDumper::Visit(const ExprStmtNode& expr_stmt) {
@@ -161,47 +161,47 @@ void AstDumper::Visit(const ExprStmtNode& expr_stmt) {
 }
 
 void AstDumper::Visit(const NullExprNode& null_expr) {
-  std::cout << indenter_.Indent() << "()" << std::endl;
+  std::cout << indenter_.Indent() << "()" << '\n';
 }
 
 void AstDumper::Visit(const IdExprNode& id_expr) {
   std::cout << indenter_.Indent() << id_expr.id << ": "
-            << ExprTypeToString(id_expr.type) << std::endl;
+            << ExprTypeToString(id_expr.type) << '\n';
 }
 
 void AstDumper::Visit(const IntConstExprNode& int_expr) {
   std::cout << indenter_.Indent() << int_expr.val << ": "
-            << ExprTypeToString(int_expr.type) << std::endl;
+            << ExprTypeToString(int_expr.type) << '\n';
 }
 
 void AstDumper::Visit(const UnaryExprNode& unary_expr) {
   std::cout << indenter_.Indent() << '(' << GetUnaryOperator(unary_expr.op)
-            << std::endl;
+            << '\n';
   indenter_.IncreaseLevel();
   unary_expr.operand->Accept(*this);
   indenter_.DecreaseLevel();
   std::cout << indenter_.Indent() << ')' << ": "
-            << ExprTypeToString(unary_expr.type) << std::endl;
+            << ExprTypeToString(unary_expr.type) << '\n';
 }
 
 void AstDumper::Visit(const BinaryExprNode& bin_expr) {
   std::cout << indenter_.Indent() << '(' << GetBinaryOperator(bin_expr.op)
-            << std::endl;
+            << '\n';
   indenter_.IncreaseLevel();
   bin_expr.lhs->Accept(*this);
   bin_expr.rhs->Accept(*this);
   indenter_.DecreaseLevel();
   std::cout << indenter_.Indent() << ')' << ": "
-            << ExprTypeToString(bin_expr.type) << std::endl;
+            << ExprTypeToString(bin_expr.type) << '\n';
 }
 
 void AstDumper::Visit(const SimpleAssignmentExprNode& assign_expr) {
-  std::cout << indenter_.Indent() << '(' << '=' << std::endl;
+  std::cout << indenter_.Indent() << '(' << '=' << '\n';
   indenter_.IncreaseLevel();
   std::cout << indenter_.Indent() << assign_expr.id << ": "
-            << ExprTypeToString(assign_expr.type) << std::endl;
+            << ExprTypeToString(assign_expr.type) << '\n';
   assign_expr.expr->Accept(*this);
   indenter_.DecreaseLevel();
   std::cout << indenter_.Indent() << ')' << ": "
-            << ExprTypeToString(assign_expr.expr->type) << std::endl;
+            << ExprTypeToString(assign_expr.expr->type) << '\n';
 }

--- a/src/qbe_ir_generator.cpp
+++ b/src/qbe_ir_generator.cpp
@@ -72,7 +72,10 @@ std::string GetUnaryOperator(UnaryOperator op) {
   }
 }
 
-std::map<std::string, int> id_to_num{};
+auto id_to_num  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables):
+                // Accessible only within this translation unit; declaring as a
+                // data member introduces unnecessary dependency.
+    = std::map<std::string, int>{};
 
 /// @brief Every expression generates a temporary. The local number of such
 /// temporary should be stored, so can propagate to later uses.
@@ -96,7 +99,11 @@ class PrevExprNumRecorder {
   int num_of_prev_expr_ = kNoRecord;
 };
 
-auto num_recorder = PrevExprNumRecorder{};
+auto
+    num_recorder  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables):
+                  // Accessible only within this translation unit; declaring as
+                  // a data member introduces unnecessary dependency.
+    = PrevExprNumRecorder{};
 
 }  // namespace
 

--- a/src/qbe_ir_generator.cpp
+++ b/src/qbe_ir_generator.cpp
@@ -97,21 +97,21 @@ std::map<std::string, int> id_to_num{};
 class PrevExprNumRecorder {
  public:
   void Record(int num) {
-    num_of_prev_expr = num;
+    num_of_prev_expr_ = num;
   }
 
   /// @note The local number can only be gotten once. This is to reduce the
   /// possibility of getting obsolete number.
   int NumOfPrevExpr() {
-    assert(num_of_prev_expr != kNoRecord);
-    int tmp = num_of_prev_expr;
-    num_of_prev_expr = kNoRecord;
+    assert(num_of_prev_expr_ != kNoRecord);
+    int tmp = num_of_prev_expr_;
+    num_of_prev_expr_ = kNoRecord;
     return tmp;
   }
 
  private:
   static constexpr int kNoRecord = -1;
-  int num_of_prev_expr = kNoRecord;
+  int num_of_prev_expr_ = kNoRecord;
 };
 
 auto num_recorder = PrevExprNumRecorder{};

--- a/src/qbe_ir_generator.cpp
+++ b/src/qbe_ir_generator.cpp
@@ -285,7 +285,7 @@ void QbeIrGenerator::Visit(const UnaryExprNode& unary_expr) {
   // assignment. For instance, ++i is equivalent to i += 1. We need to handle
   // this case by case.
   // @note: Temporary fix for unused 'GetUnaryOperator' function error.
-  std::string op = GetUnaryOperator(unary_expr.op);
+  GetUnaryOperator(unary_expr.op);
 }
 
 void QbeIrGenerator::Visit(const BinaryExprNode& bin_expr) {

--- a/src/qbe_ir_generator.cpp
+++ b/src/qbe_ir_generator.cpp
@@ -86,7 +86,9 @@ std::string GetUnaryOperator(UnaryOperator op) {
 /// @note This is a convenience function to avoid having to pass `output`
 /// everywhere.
 template <typename... T>
-void WriteOut(fmt::format_string<T...> format, T&&... args) {
+void WriteOut(fmt::format_string<T...> format,
+              T&&... args) {  // NOLINT(cppcoreguidelines-missing-std-forward):
+                              // `make_format_args` takes rvalue references.
   VWriteOut(format, fmt::make_format_args(args...));
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -4,7 +4,9 @@
 #include <string>
 
 std::string Indenter::Indent() const {
-  return std::string(size_per_level_ * level_, symbol_);
+  return std::string(  // NOLINT(modernize-return-braced-init-list:
+                       // False-positive on (size, value) constructor.
+      size_per_level_ * level_, symbol_);
 }
 
 void Indenter::IncreaseLevel() {


### PR DESCRIPTION
This pull request addresses linting errors reported by clang-tidy. Each commit message provides insight into the rationale behind the solution, offering an opportunity to learn best practices in C++. We encourage reviewers to go through each commit message to gain a deeper understanding. :laughing:

Additionally, the bug reported in #76 is resolved together with [Exclude generated files from tidy checks](https://github.com/fruits-lab/VitaminC/pull/78/commits/249d32aacc02829188ff9a60c5566007a521d902).

Resolves: #75
Resolves: #76 