### PR TITLE
Mix declarations and statements in compound statement

### DIFF
--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -88,15 +88,14 @@ struct LoopInitNode : public AstNode {
 };
 
 struct CompoundStmtNode : public StmtNode {
-  CompoundStmtNode(std::vector<std::unique_ptr<DeclNode>>&& decls,
-                   std::vector<std::unique_ptr<StmtNode>>&& stmts)
-      : decls{std::move(decls)}, stmts{std::move(stmts)} {}
+  using Item =
+      std::variant<std::unique_ptr<DeclNode>, std::unique_ptr<StmtNode>>;
+  CompoundStmtNode(std::vector<Item> items) : items{std::move(items)} {}
 
   void Accept(NonModifyingVisitor&) const override;
   void Accept(ModifyingVisitor&) override;
 
-  std::vector<std::unique_ptr<DeclNode>> decls;
-  std::vector<std::unique_ptr<StmtNode>> stmts;
+  std::vector<Item> items;
 };
 
 /// @brief Root of the entire program.

--- a/src/ast_dumper.cpp
+++ b/src/ast_dumper.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <variant>
 
 #include "ast.hpp"
 #include "type.hpp"
@@ -83,11 +84,8 @@ void AstDumper::Visit(const LoopInitNode& loop_init) {
 }
 
 void AstDumper::Visit(const CompoundStmtNode& compound_stmt) {
-  for (const auto& decl : compound_stmt.decls) {
-    decl->Accept(*this);
-  }
-  for (const auto& stmt : compound_stmt.stmts) {
-    stmt->Accept(*this);
+  for (const auto& item : compound_stmt.items) {
+    std::visit([this](auto&& item) { item->Accept(*this); }, item);
   }
 }
 

--- a/src/qbe_ir_generator.cpp
+++ b/src/qbe_ir_generator.cpp
@@ -136,11 +136,8 @@ void QbeIrGenerator::Visit(const CompoundStmtNode& compound_stmt) {
   // because it doesn't know whether it is a if statement body or a function.
   // Thus, by moving label creation to an upper level, each block can have its
   // correct starting label.
-  for (const auto& decl : compound_stmt.decls) {
-    decl->Accept(*this);
-  }
-  for (const auto& stmt : compound_stmt.stmts) {
-    stmt->Accept(*this);
+  for (const auto& item : compound_stmt.items) {
+    std::visit([this](auto&& item) { item->Accept(*this); }, item);
   }
 }
 

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -33,11 +33,8 @@ void TypeChecker::Visit(LoopInitNode& loop_init) {
 
 void TypeChecker::Visit(CompoundStmtNode& compound_stmt) {
   env_.PushScope();
-  for (auto& decl : compound_stmt.decls) {
-    decl->Accept(*this);
-  }
-  for (auto& stmt : compound_stmt.stmts) {
-    stmt->Accept(*this);
+  for (auto& item : compound_stmt.items) {
+    std::visit([this](auto&& item) { item->Accept(*this); }, item);
   }
   env_.PopScope();
 }

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -24,11 +24,8 @@ void TypeChecker::Visit(DeclNode& decl) {
 }
 
 void TypeChecker::Visit(LoopInitNode& loop_init) {
-  if (std::holds_alternative<std::unique_ptr<DeclNode>>(loop_init.clause)) {
-    std::get<std::unique_ptr<DeclNode>>(loop_init.clause)->Accept(*this);
-  } else {
-    std::get<std::unique_ptr<ExprNode>>(loop_init.clause)->Accept(*this);
-  }
+  std::visit([this](auto&& clause) { clause->Accept(*this); },
+             loop_init.clause);
 }
 
 void TypeChecker::Visit(CompoundStmtNode& compound_stmt) {

--- a/test/typecheck/compound_stmt.c
+++ b/test/typecheck/compound_stmt.c
@@ -1,5 +1,6 @@
 int main() {
   int i = 1;
+  i = i + 1;
   int j = 2;
   return i + j;
 }

--- a/test/typecheck/compound_stmt.exp
+++ b/test/typecheck/compound_stmt.exp
@@ -1,6 +1,13 @@
 (i: int =
   1: int
 )
+(=
+  i: int
+  (+
+    i: int
+    1: int
+  ): int
+): int
 (j: int =
   2: int
 )


### PR DESCRIPTION
This enhancement allows for declarations and statements to interleave within compound statements.
I follow the reference manual, naming the "nodes" inside the compound statement as `item`.

> [!note]
> Previously, there was a discussion regarding the use of `std::visit` when dispatching on `std::variant`. Initially, `std::visit` was considered less readable (see https://github.com/fruits-lab/VitaminC/pull/56#discussion_r1418991588).
> Upon reconsideration, it was realized that the actual underlying type is irrelevant, as the types are polymorphic and always call the `Accept` function. Therefore, using `std::visit` hides unnecessary detail, which is preferable to verbose holding conditions using `std::holds_alternative`.

Resolves: #79 