### PR TITLE
Exclude test files from tidy check

### DIFF
--- a/scripts/check-tidy-diff.sh
+++ b/scripts/check-tidy-diff.sh
@@ -23,4 +23,4 @@ command -v bear >/dev/null 2>&1 || (
 make clean
 bear -- make
 git fetch origin "${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
-git diff -U0 "origin/${GITHUB_BASE_REF}" | ${CLANG_TIDY_DIFF} -p1
+git diff -U0 "origin/${GITHUB_BASE_REF}" -- ':test/' | ${CLANG_TIDY_DIFF} -p1


### PR DESCRIPTION
Previously, clang-tidy-diff was applied to all changed files, including those under the test/ directory. However, these files are not production code and may contain unusual constructs. Therefore, we exclude them from the output of `git diff`, ensuring they are not checked by clang-tidy.

For more details, please refer to [Making 'git log' ignore changes for certain paths](https://stackoverflow.com/questions/5685007/making-git-log-ignore-changes-for-certain-paths/21079437#21079437).