### PR TITLE
Drop build of examples/tests of library to speed up installation

### DIFF
--- a/scripts/install-cxxopts.sh
+++ b/scripts/install-cxxopts.sh
@@ -3,7 +3,7 @@
 wget https://github.com/jarro2783/cxxopts/archive/refs/tags/v3.1.1.tar.gz -O - | tar zxf - &&
   cd cxxopts-3.1.1/ &&
   mkdir build/ &&
-  cmake -B build/ . &&
+  cmake -DCXXOPTS_BUILD_EXAMPLES=OFF -DCXXOPTS_BUILD_TESTS=OFF -B build/ . &&
   sudo make -C build/ install &&
   cd .. &&
   rm -rf cxxopts-3.1.1/

--- a/scripts/install-fmt.sh
+++ b/scripts/install-fmt.sh
@@ -16,7 +16,7 @@ esac
 wget https://github.com/fmtlib/fmt/archive/refs/tags/10.1.1.tar.gz -O - | tar zxf - &&
   cd fmt-10.1.1/ &&
   mkdir build/ &&
-  cmake -B build/ . &&
+  cmake -DFMT_TEST=false -B build/ . &&
   sudo make -j"${NPROCS}" -C build/ install &&
   cd .. &&
   rm -rf fmt-10.1.1/


### PR DESCRIPTION
By default, the tests of fmt and the examples/tests of cxxopts are also built during installation, which slows down our CI process. Since we will not run the fmt tests or those of cxxopts, building them is unnecessary.