### PR TITLE
Add bison flags to generate better error messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LEX = lex
 # C++ features are used, yacc doesn't suffice
 YACC = bison
 # -d: generate header with default name
-YFLAGS = --verbose --debug -d
+YFLAGS = --verbose --debug -d -Wcounterexamples -Wall
 # Check if -j multiple jobs is configured.
 PARALLEL = false
 ifneq (,$(findstring j,$(MAKEFLAGS)))

--- a/parser.y
+++ b/parser.y
@@ -77,7 +77,7 @@
 %nterm <CompoundStmtNode::Item> block_item
 %nterm <std::unique_ptr<CompoundStmtNode>> main_func
 
-%left '='
+%precedence '='
 %left EQ NE
 %left '<' '>' LE GE
 %left '+' '-'
@@ -224,7 +224,7 @@ primary_expr: ID { $$ = std::make_unique<IdExprNode>($1); }
   | '(' expr ')' { $$ = $2; }
   ;
 
-epsilon: /* empty */ ;
+epsilon: %empty;
 %%
 
 void yy::parser::error(const std::string& err) {


### PR DESCRIPTION
`-Wcounterexample` generates the following example for solving conflicts.

```
Example: INCR expr • '+' expr
  Shift derivation
    expr
    ↳ 29: unary_expr
          ↳ 43: INCR expr
                     ↳ 30: expr • '+' expr
  Reduce derivation
    expr
    ↳ 30: expr                    '+' expr
          ↳ 29: unary_expr
                ↳ 43: INCR expr •
...
```