### PR TITLE
Prefix labels with the name of the statement

### DIFF
--- a/src/qbe_ir_generator.cpp
+++ b/src/qbe_ir_generator.cpp
@@ -167,9 +167,9 @@ void QbeIrGenerator::Visit(const IfStmtNode& if_stmt) {
   if_stmt.predicate->Accept(*this);
   int predicate_num = num_recorder.NumOfPrevExpr();
   int label_num = NextLabelNum();
-  auto then_label = BlockLabel{"then", label_num};
-  auto else_label = BlockLabel{"else", label_num};
-  auto end_label = BlockLabel{"end", label_num};
+  auto then_label = BlockLabel{"if_then", label_num};
+  auto else_label = BlockLabel{"if_else", label_num};
+  auto end_label = BlockLabel{"if_end", label_num};
 
   // Jumps to "then" if the predicate is true (non-zero), else jumps to "else".
   // If no "else" exists, falls through to "end".
@@ -200,9 +200,11 @@ void QbeIrGenerator::Visit(const IfStmtNode& if_stmt) {
 
 void QbeIrGenerator::Visit(const WhileStmtNode& while_stmt) {
   int label_num = NextLabelNum();
-  auto body_label = BlockLabel{"loop_body", label_num};
-  auto pred_label = BlockLabel{"pred", label_num};
-  auto end_label = BlockLabel{"end", label_num};
+  const auto label_prefix =
+      std::string{while_stmt.is_do_while ? "do_" : "while_"};
+  auto body_label = BlockLabel{label_prefix + "body", label_num};
+  auto pred_label = BlockLabel{label_prefix + "pred", label_num};
+  auto end_label = BlockLabel{label_prefix + "end", label_num};
 
   // A while statement's predicate is evaluated "before" the body statement,
   // whereas a do-while statement's predicate is evaluated "after" the body
@@ -239,10 +241,10 @@ void QbeIrGenerator::Visit(const ForStmtNode& for_stmt) {
   // A for loop consists of three clauses: loop initialization, predicate, and a
   // step: for (init; pred; step) { body; }
 
-  auto pred_label = BlockLabel{"pred", label_num};
-  auto body_label = BlockLabel{"loop_body", label_num};
-  auto step_label = BlockLabel{"step", label_num};
-  auto end_label = BlockLabel{"end", label_num};
+  auto pred_label = BlockLabel{"for_pred", label_num};
+  auto body_label = BlockLabel{"for_body", label_num};
+  auto step_label = BlockLabel{"for_step", label_num};
+  auto end_label = BlockLabel{"for_end", label_num};
 
   // A for statement's loop initialization is the first clause to execute,
   // whereas a for statement's predicate specifies evaluation made before each


### PR DESCRIPTION
While debugging loops and conditions in the QBE IR, I noticed that the labels for different types of loops were too similar. To enhance clarity and facilitate mapping back to the C source code, I have renamed the labels accordingly.

```
$ cat test/codegen/break_stmt.c.ssa
export function w $main() {
@start
%.1 =l alloc4 4
%.2 =w copy 0
storew %.2, %.1
%.3 =l alloc4 4
%.4 =w copy 0
storew %.4, %.3
@.while_pred.1
%.5 =w loadw %.1
%.6 =w copy 10
%.7 =w csltw %.5, %.6
jnz %.7, @.while_body.1, @.while_end.1
@.while_body.1
%.8 =w loadw %.1
%.9 =w copy 3
%.10 =w ceqw %.8, %.9
# if
jnz %.10, @.if_then.2, @.if_end.2
@.if_then.2
jmp @.while_end.1
@.if_end.2
%.11 =w loadw %.3
%.12 =w copy 1
%.13 =w add %.11, %.12
storew %.13, %.3
%.14 =w loadw %.1
%.15 =w copy 1
%.16 =w add %.14, %.15
storew %.16, %.1
jmp @.while_pred.1
@.while_end.1
%.17 =w copy 0
storew %.17, %.1
@.do_body.3
%.18 =w loadw %.1
%.19 =w copy 5
%.20 =w ceqw %.18, %.19
# if
jnz %.20, @.if_then.4, @.if_end.4
@.if_then.4
jmp @.do_end.3
@.if_end.4
%.21 =w loadw %.3
%.22 =w copy 1
%.23 =w add %.21, %.22
storew %.23, %.3
%.24 =w loadw %.1
%.25 =w copy 1
%.26 =w add %.24, %.25
storew %.26, %.1
@.do_pred.3
%.27 =w loadw %.1
%.28 =w copy 10
%.29 =w csltw %.27, %.28
jnz %.29, @.do_body.3, @.do_end.3
@.do_end.3
# loop init
%.30 =w copy 0
storew %.30, %.1
@.for_pred.5
%.31 =w loadw %.1
%.32 =w copy 10
%.33 =w csltw %.31, %.32
jnz %.33, @.for_body.5, @.for_end.5
@.for_body.5
%.34 =w loadw %.1
%.35 =w copy 7
%.36 =w ceqw %.34, %.35
# if
jnz %.36, @.if_then.6, @.if_end.6
@.if_then.6
jmp @.for_end.5
@.if_end.6
%.37 =w loadw %.3
%.38 =w copy 1
%.39 =w add %.37, %.38
storew %.39, %.3
@.for_step.5
%.40 =w loadw %.1
%.41 =w copy 1
%.42 =w add %.40, %.41
storew %.42, %.1
jmp @.for_pred.5
@.for_end.5
%.43 =w loadw %.3
ret %.43
}
```