### PR TITLE
Indent generated QBE IR

### DIFF
--- a/include/qbe_ir_generator.hpp
+++ b/include/qbe_ir_generator.hpp
@@ -4,8 +4,10 @@
 #include <fmt/core.h>
 
 #include <iosfwd>
+#include <utility>
 
 #include "ast.hpp"
+#include "qbe/sigil.hpp"
 #include "visitor.hpp"
 
 class QbeIrGenerator : public NonModifyingVisitor {
@@ -35,7 +37,33 @@ class QbeIrGenerator : public NonModifyingVisitor {
  private:
   std::ostream& output_;
 
-  /// @brief Writes out the formatted string to `output`.
+  static constexpr auto kIndentStr = "\t";
+
+  /// @brief Writes a single instruction with newline.
+  /// @note The instruction is indented.
+  template <typename... T>
+  void WriteInstr_(fmt::format_string<T...> format, T&&... args) {
+    Write_(kIndentStr);
+    Write_(format, std::forward<T>(args)...);
+    Write_("\n");
+  }
+
+  /// @brief Writes the definition of a label with newline.
+  void WriteLabel_(const qbe::BlockLabel& label) {
+    Write_("{}\n", label);
+  }
+
+  /// @brief Writes the `# ` comment with newline.
+  template <typename... T>
+  void WriteComment_(fmt::format_string<T...> format, T&&... args) {
+    Write_("# ");
+    Write_(format, std::forward<T>(args)...);
+    Write_("\n");
+  }
+
+  /// @brief Writes the formatted string to `output`; can be used to write
+  /// multiple instructions and labels at once. The format is fully specified by
+  /// the user.
   /// @note This is a convenience function to avoid having to pass `output`
   /// everywhere.
   template <typename... T>

--- a/include/qbe_ir_generator.hpp
+++ b/include/qbe_ir_generator.hpp
@@ -39,15 +39,14 @@ class QbeIrGenerator : public NonModifyingVisitor {
   /// @note This is a convenience function to avoid having to pass `output`
   /// everywhere.
   template <typename... T>
-  void WriteOut_(
-      fmt::format_string<T...> format,
-      T&&... args) {  // NOLINT(cppcoreguidelines-missing-std-forward):
-                      // `make_format_args` takes rvalue references.
-    VWriteOut_(format, fmt::make_format_args(args...));
+  void Write_(fmt::format_string<T...> format,
+              T&&... args) {  // NOLINT(cppcoreguidelines-missing-std-forward):
+                              // `make_format_args` takes rvalue references.
+    VWrite_(format, fmt::make_format_args(args...));
   }
 
   /// @note This function is not meant to be used directly.
-  void VWriteOut_(fmt::string_view format, fmt::format_args args);
+  void VWrite_(fmt::string_view format, fmt::format_args args);
 };
 
 #endif  // QBE_IR_GENERATOR_HPP_

--- a/src/qbe_ir_generator.cpp
+++ b/src/qbe_ir_generator.cpp
@@ -112,12 +112,13 @@ auto
 
 void QbeIrGenerator::Visit(const DeclNode& decl) {
   int id_num = NextLocalNum();
-  Write_("{} =l alloc4 4\n", FuncScopeTemp{id_num});
+  WriteInstr_("{} =l alloc4 4", FuncScopeTemp{id_num});
 
   if (decl.init) {
     decl.init->Accept(*this);
     int init_num = num_recorder.NumOfPrevExpr();
-    Write_("storew {}, {}\n", FuncScopeTemp{init_num}, FuncScopeTemp{id_num});
+    WriteInstr_("storew {}, {}", FuncScopeTemp{init_num},
+                FuncScopeTemp{id_num});
   }
   // Set up the number of the id so we know were to load it back.
   id_to_num[decl.id] = id_num;
@@ -174,27 +175,24 @@ void QbeIrGenerator::Visit(const IfStmtNode& if_stmt) {
   // If no "else" exists, falls through to "end".
   // If "else" exists, a second jump is needed after executing "then" to skip
   // it, as the generated code for "else" follows immediately after "then".
-  Write_(
-      "# if\n"
-      "jnz {}, {}, ",
-      FuncScopeTemp{predicate_num}, then_label);
+  WriteComment_("if");
+  Write_("{}jnz {}, {}, ", kIndentStr, FuncScopeTemp{predicate_num},
+         then_label);
   if (if_stmt.or_else) {
     Write_("{}\n", else_label);
   } else {
     Write_("{}\n", end_label);
   }
 
-  Write_("{}\n", then_label);
+  WriteLabel_(then_label);
   if_stmt.then->Accept(*this);
   if (if_stmt.or_else) {
     // Skip the "else" part after executing "then".
-    Write_(
-        "jmp {}\n"
-        "{}\n",
-        end_label, else_label);
+    WriteInstr_("jmp {}\n", end_label);
+    WriteLabel_(else_label);
     if_stmt.or_else->Accept(*this);
   }
-  Write_("{}\n", end_label);
+  WriteLabel_(end_label);
 }
 
 void QbeIrGenerator::Visit(const WhileStmtNode& while_stmt) {
@@ -209,27 +207,27 @@ void QbeIrGenerator::Visit(const WhileStmtNode& while_stmt) {
   // unconditional jump at the end of the body to jump back to the predicate.
   // For a do-while statement, it only needs one conditional jump.
   if (!while_stmt.is_do_while) {
-    Write_("{}\n", pred_label);
+    WriteLabel_(pred_label);
     while_stmt.predicate->Accept(*this);
     int predicate_num = num_recorder.NumOfPrevExpr();
-    Write_("jnz {}, {}, {}\n", FuncScopeTemp{predicate_num}, body_label,
-           end_label);
+    WriteInstr_("jnz {}, {}, {}", FuncScopeTemp{predicate_num}, body_label,
+                end_label);
   }
-  Write_("{}\n", body_label);
+  WriteLabel_(body_label);
   label_views_of_jumpable_blocks.push_back(
       {.entry = pred_label.name(), .exit = end_label.name()});
   while_stmt.loop_body->Accept(*this);
   label_views_of_jumpable_blocks.pop_back();
   if (!while_stmt.is_do_while) {
-    Write_("jmp {}\n", pred_label);
+    WriteInstr_("jmp {}", pred_label);
   } else {
-    Write_("{}\n", pred_label);
+    WriteLabel_(pred_label);
     while_stmt.predicate->Accept(*this);
     int predicate_num = num_recorder.NumOfPrevExpr();
-    Write_("jnz {}, {}, {}\n", FuncScopeTemp{predicate_num}, body_label,
-           end_label);
+    WriteInstr_("jnz {}, {}, {}", FuncScopeTemp{predicate_num}, body_label,
+                end_label);
   }
-  Write_("{}\n", end_label);
+  WriteLabel_(end_label);
 }
 
 void QbeIrGenerator::Visit(const ForStmtNode& for_stmt) {
@@ -247,42 +245,41 @@ void QbeIrGenerator::Visit(const ForStmtNode& for_stmt) {
   // whereas a for statement's predicate specifies evaluation made before each
   // iteration. A step is an operation that is performed after each iteration.
   // Skip predicate generation if it is a null expression.
-  Write_("# loop init\n");
+  WriteComment_("loop init");
   for_stmt.loop_init->Accept(*this);
-  Write_("{}\n", pred_label);
+  WriteLabel_(pred_label);
   for_stmt.predicate->Accept(*this);
   if (!dynamic_cast<NullExprNode*>((for_stmt.predicate).get())) {
     int predicate_num = num_recorder.NumOfPrevExpr();
-    Write_("jnz {}, {}, {}\n", FuncScopeTemp{predicate_num}, body_label,
-           end_label);
+    WriteInstr_("jnz {}, {}, {}", FuncScopeTemp{predicate_num}, body_label,
+                end_label);
   }
-  Write_("{}\n", body_label);
+  WriteLabel_(body_label);
   label_views_of_jumpable_blocks.push_back(
       {.entry = step_label.name(), .exit = end_label.name()});
   for_stmt.loop_body->Accept(*this);
   label_views_of_jumpable_blocks.pop_back();
-  Write_("{}\n", step_label);
+  WriteLabel_(step_label);
   for_stmt.step->Accept(*this);
-  Write_(
-      "jmp {}\n"
-      "{}\n",
-      pred_label, end_label);
+  WriteInstr_("jmp {}", pred_label);
+  WriteLabel_(end_label);
 }
 
 void QbeIrGenerator::Visit(const ReturnStmtNode& ret_stmt) {
   ret_stmt.expr->Accept(*this);
   int ret_num = num_recorder.NumOfPrevExpr();
-  Write_("ret {}\n", FuncScopeTemp{ret_num});
+  WriteInstr_("ret {}", FuncScopeTemp{ret_num});
 }
 
 void QbeIrGenerator::Visit(const BreakStmtNode& break_stmt) {
   assert(!label_views_of_jumpable_blocks.empty());
-  Write_("jmp {}\n", BlockLabel{label_views_of_jumpable_blocks.back().exit});
+  WriteInstr_("jmp {}", BlockLabel{label_views_of_jumpable_blocks.back().exit});
 }
 
 void QbeIrGenerator::Visit(const ContinueStmtNode& continue_stmt) {
   assert(!label_views_of_jumpable_blocks.empty());
-  Write_("jmp {}\n", BlockLabel{label_views_of_jumpable_blocks.back().entry});
+  WriteInstr_("jmp {}",
+              BlockLabel{label_views_of_jumpable_blocks.back().entry});
 }
 
 void QbeIrGenerator::Visit(const ExprStmtNode& expr_stmt) {
@@ -298,13 +295,13 @@ void QbeIrGenerator::Visit(const IdExprNode& id_expr) {
   /// the register before use.
   int id_num = id_to_num.at(id_expr.id);
   int reg_num = NextLocalNum();
-  Write_("{} =w loadw {}\n", FuncScopeTemp{reg_num}, FuncScopeTemp{id_num});
+  WriteInstr_("{} =w loadw {}", FuncScopeTemp{reg_num}, FuncScopeTemp{id_num});
   num_recorder.Record(reg_num);
 }
 
 void QbeIrGenerator::Visit(const IntConstExprNode& int_expr) {
   int num = NextLocalNum();
-  Write_("{} =w copy {}\n", FuncScopeTemp{num}, int_expr.val);
+  WriteInstr_("{} =w copy {}", FuncScopeTemp{num}, int_expr.val);
   num_recorder.Record(num);
 }
 
@@ -312,7 +309,7 @@ void QbeIrGenerator::Visit(const FunCallExprNode& call_expr) {
   const auto* id_expr = dynamic_cast<IdExprNode*>((call_expr.func_expr).get());
   assert(id_expr);
   const int res_num = NextLocalNum();
-  Write_("{} =w call ${}()\n", FuncScopeTemp{res_num}, id_expr->id);
+  WriteInstr_("{} =w call ${}()", FuncScopeTemp{res_num}, id_expr->id);
   num_recorder.Record(res_num);
 }
 
@@ -327,13 +324,13 @@ void QbeIrGenerator::Visit(const UnaryExprNode& unary_expr) {
       const auto arith_op = unary_expr.op == UnaryOperator::kIncr
                                 ? BinaryOperator::kAdd
                                 : BinaryOperator::kSub;
-      Write_("{} =w {} {}, 1\n", FuncScopeTemp{res_num},
-             GetBinaryOperator(arith_op), FuncScopeTemp{expr_num});
+      WriteInstr_("{} =w {} {}, 1", FuncScopeTemp{res_num},
+                  GetBinaryOperator(arith_op), FuncScopeTemp{expr_num});
       const auto* id_expr =
           dynamic_cast<IdExprNode*>((unary_expr.operand).get());
       assert(id_expr);
-      Write_("storew {}, {}\n", FuncScopeTemp{res_num},
-             FuncScopeTemp{id_to_num.at(id_expr->id)});
+      WriteInstr_("storew {}, {}", FuncScopeTemp{res_num},
+                  FuncScopeTemp{id_to_num.at(id_expr->id)});
       num_recorder.Record(res_num);
     } break;
     case UnaryOperator::kPos:
@@ -342,7 +339,8 @@ void QbeIrGenerator::Visit(const UnaryExprNode& unary_expr) {
     case UnaryOperator::kNeg: {
       const int expr_num = num_recorder.NumOfPrevExpr();
       const int res_num = NextLocalNum();
-      Write_("{} =w neg {}\n", FuncScopeTemp{res_num}, FuncScopeTemp{expr_num});
+      WriteInstr_("{} =w neg {}", FuncScopeTemp{res_num},
+                  FuncScopeTemp{expr_num});
       num_recorder.Record(res_num);
     } break;
     case UnaryOperator::kNot: {
@@ -351,16 +349,17 @@ void QbeIrGenerator::Visit(const UnaryExprNode& unary_expr) {
       // The expression !E is equivalent to (0 == E).
       const int expr_num = num_recorder.NumOfPrevExpr();
       const int res_num = NextLocalNum();
-      Write_("{} =w {} {}, 0\n", FuncScopeTemp{res_num},
-             GetBinaryOperator(BinaryOperator::kEq), FuncScopeTemp{expr_num});
+      WriteInstr_("{} =w {} {}, 0", FuncScopeTemp{res_num},
+                  GetBinaryOperator(BinaryOperator::kEq),
+                  FuncScopeTemp{expr_num});
       num_recorder.Record(res_num);
     } break;
     case UnaryOperator::kBitComp: {
       const int expr_num = num_recorder.NumOfPrevExpr();
       const int res_num = NextLocalNum();
       // Exclusive or with all ones to flip the bits.
-      Write_("{} =w xor {}, -1\n", FuncScopeTemp{res_num},
-             FuncScopeTemp{expr_num});
+      WriteInstr_("{} =w xor {}, -1", FuncScopeTemp{res_num},
+                  FuncScopeTemp{expr_num});
       num_recorder.Record(res_num);
     } break;
     default:
@@ -377,17 +376,17 @@ void QbeIrGenerator::Visit(const BinaryExprNode& bin_expr) {
   // TODO: use the correct instruction for specific data type:
   // 1. signed or unsigned: currently only supports signed integers.
   // 2. QBE base data type 'w' | 'l' | 's' | 'd': currently only supports 'w'.
-  Write_("{} =w {} {}, {}\n", FuncScopeTemp{num},
-         GetBinaryOperator(bin_expr.op), FuncScopeTemp{left_num},
-         FuncScopeTemp{right_num});
+  WriteInstr_("{} =w {} {}, {}", FuncScopeTemp{num},
+              GetBinaryOperator(bin_expr.op), FuncScopeTemp{left_num},
+              FuncScopeTemp{right_num});
   num_recorder.Record(num);
 }
 
 void QbeIrGenerator::Visit(const SimpleAssignmentExprNode& assign_expr) {
   assign_expr.expr->Accept(*this);
   int expr_num = num_recorder.NumOfPrevExpr();
-  Write_("storew {}, {}\n", FuncScopeTemp{expr_num},
-         FuncScopeTemp{id_to_num.at(assign_expr.id)});
+  WriteInstr_("storew {}, {}", FuncScopeTemp{expr_num},
+              FuncScopeTemp{id_to_num.at(assign_expr.id)});
   num_recorder.Record(expr_num);
 }
 

--- a/src/qbe_ir_generator.cpp
+++ b/src/qbe_ir_generator.cpp
@@ -112,25 +112,24 @@ auto
 
 void QbeIrGenerator::Visit(const DeclNode& decl) {
   int id_num = NextLocalNum();
-  WriteOut_("{} =l alloc4 4\n", FuncScopeTemp{id_num});
+  Write_("{} =l alloc4 4\n", FuncScopeTemp{id_num});
 
   if (decl.init) {
     decl.init->Accept(*this);
     int init_num = num_recorder.NumOfPrevExpr();
-    WriteOut_("storew {}, {}\n", FuncScopeTemp{init_num},
-              FuncScopeTemp{id_num});
+    Write_("storew {}, {}\n", FuncScopeTemp{init_num}, FuncScopeTemp{id_num});
   }
   // Set up the number of the id so we know were to load it back.
   id_to_num[decl.id] = id_num;
 }
 
 void QbeIrGenerator::Visit(const FuncDefNode& func_def) {
-  WriteOut_(
+  Write_(
       "export function w ${}() {{\n"
       "@start\n",
       func_def.id);
   func_def.body->Accept(*this);
-  WriteOut_("}}\n");
+  Write_("}}\n");
 }
 
 void QbeIrGenerator::Visit(const LoopInitNode& loop_init) {
@@ -156,11 +155,11 @@ void QbeIrGenerator::Visit(const ProgramNode& program) {
     func_def->Accept(*this);
   }
 
-  WriteOut_(
+  Write_(
       "export function w $main() {{\n"
       "@start\n");
   program.body->Accept(*this);
-  WriteOut_("}}");
+  Write_("}}");
 }
 
 void QbeIrGenerator::Visit(const IfStmtNode& if_stmt) {
@@ -175,27 +174,27 @@ void QbeIrGenerator::Visit(const IfStmtNode& if_stmt) {
   // If no "else" exists, falls through to "end".
   // If "else" exists, a second jump is needed after executing "then" to skip
   // it, as the generated code for "else" follows immediately after "then".
-  WriteOut_(
+  Write_(
       "# if\n"
       "jnz {}, {}, ",
       FuncScopeTemp{predicate_num}, then_label);
   if (if_stmt.or_else) {
-    WriteOut_("{}\n", else_label);
+    Write_("{}\n", else_label);
   } else {
-    WriteOut_("{}\n", end_label);
+    Write_("{}\n", end_label);
   }
 
-  WriteOut_("{}\n", then_label);
+  Write_("{}\n", then_label);
   if_stmt.then->Accept(*this);
   if (if_stmt.or_else) {
     // Skip the "else" part after executing "then".
-    WriteOut_(
+    Write_(
         "jmp {}\n"
         "{}\n",
         end_label, else_label);
     if_stmt.or_else->Accept(*this);
   }
-  WriteOut_("{}\n", end_label);
+  Write_("{}\n", end_label);
 }
 
 void QbeIrGenerator::Visit(const WhileStmtNode& while_stmt) {
@@ -210,27 +209,27 @@ void QbeIrGenerator::Visit(const WhileStmtNode& while_stmt) {
   // unconditional jump at the end of the body to jump back to the predicate.
   // For a do-while statement, it only needs one conditional jump.
   if (!while_stmt.is_do_while) {
-    WriteOut_("{}\n", pred_label);
+    Write_("{}\n", pred_label);
     while_stmt.predicate->Accept(*this);
     int predicate_num = num_recorder.NumOfPrevExpr();
-    WriteOut_("jnz {}, {}, {}\n", FuncScopeTemp{predicate_num}, body_label,
-              end_label);
+    Write_("jnz {}, {}, {}\n", FuncScopeTemp{predicate_num}, body_label,
+           end_label);
   }
-  WriteOut_("{}\n", body_label);
+  Write_("{}\n", body_label);
   label_views_of_jumpable_blocks.push_back(
       {.entry = pred_label.name(), .exit = end_label.name()});
   while_stmt.loop_body->Accept(*this);
   label_views_of_jumpable_blocks.pop_back();
   if (!while_stmt.is_do_while) {
-    WriteOut_("jmp {}\n", pred_label);
+    Write_("jmp {}\n", pred_label);
   } else {
-    WriteOut_("{}\n", pred_label);
+    Write_("{}\n", pred_label);
     while_stmt.predicate->Accept(*this);
     int predicate_num = num_recorder.NumOfPrevExpr();
-    WriteOut_("jnz {}, {}, {}\n", FuncScopeTemp{predicate_num}, body_label,
-              end_label);
+    Write_("jnz {}, {}, {}\n", FuncScopeTemp{predicate_num}, body_label,
+           end_label);
   }
-  WriteOut_("{}\n", end_label);
+  Write_("{}\n", end_label);
 }
 
 void QbeIrGenerator::Visit(const ForStmtNode& for_stmt) {
@@ -248,23 +247,23 @@ void QbeIrGenerator::Visit(const ForStmtNode& for_stmt) {
   // whereas a for statement's predicate specifies evaluation made before each
   // iteration. A step is an operation that is performed after each iteration.
   // Skip predicate generation if it is a null expression.
-  WriteOut_("# loop init\n");
+  Write_("# loop init\n");
   for_stmt.loop_init->Accept(*this);
-  WriteOut_("{}\n", pred_label);
+  Write_("{}\n", pred_label);
   for_stmt.predicate->Accept(*this);
   if (!dynamic_cast<NullExprNode*>((for_stmt.predicate).get())) {
     int predicate_num = num_recorder.NumOfPrevExpr();
-    WriteOut_("jnz {}, {}, {}\n", FuncScopeTemp{predicate_num}, body_label,
-              end_label);
+    Write_("jnz {}, {}, {}\n", FuncScopeTemp{predicate_num}, body_label,
+           end_label);
   }
-  WriteOut_("{}\n", body_label);
+  Write_("{}\n", body_label);
   label_views_of_jumpable_blocks.push_back(
       {.entry = step_label.name(), .exit = end_label.name()});
   for_stmt.loop_body->Accept(*this);
   label_views_of_jumpable_blocks.pop_back();
-  WriteOut_("{}\n", step_label);
+  Write_("{}\n", step_label);
   for_stmt.step->Accept(*this);
-  WriteOut_(
+  Write_(
       "jmp {}\n"
       "{}\n",
       pred_label, end_label);
@@ -273,18 +272,17 @@ void QbeIrGenerator::Visit(const ForStmtNode& for_stmt) {
 void QbeIrGenerator::Visit(const ReturnStmtNode& ret_stmt) {
   ret_stmt.expr->Accept(*this);
   int ret_num = num_recorder.NumOfPrevExpr();
-  WriteOut_("ret {}\n", FuncScopeTemp{ret_num});
+  Write_("ret {}\n", FuncScopeTemp{ret_num});
 }
 
 void QbeIrGenerator::Visit(const BreakStmtNode& break_stmt) {
   assert(!label_views_of_jumpable_blocks.empty());
-  WriteOut_("jmp {}\n", BlockLabel{label_views_of_jumpable_blocks.back().exit});
+  Write_("jmp {}\n", BlockLabel{label_views_of_jumpable_blocks.back().exit});
 }
 
 void QbeIrGenerator::Visit(const ContinueStmtNode& continue_stmt) {
   assert(!label_views_of_jumpable_blocks.empty());
-  WriteOut_("jmp {}\n",
-            BlockLabel{label_views_of_jumpable_blocks.back().entry});
+  Write_("jmp {}\n", BlockLabel{label_views_of_jumpable_blocks.back().entry});
 }
 
 void QbeIrGenerator::Visit(const ExprStmtNode& expr_stmt) {
@@ -300,13 +298,13 @@ void QbeIrGenerator::Visit(const IdExprNode& id_expr) {
   /// the register before use.
   int id_num = id_to_num.at(id_expr.id);
   int reg_num = NextLocalNum();
-  WriteOut_("{} =w loadw {}\n", FuncScopeTemp{reg_num}, FuncScopeTemp{id_num});
+  Write_("{} =w loadw {}\n", FuncScopeTemp{reg_num}, FuncScopeTemp{id_num});
   num_recorder.Record(reg_num);
 }
 
 void QbeIrGenerator::Visit(const IntConstExprNode& int_expr) {
   int num = NextLocalNum();
-  WriteOut_("{} =w copy {}\n", FuncScopeTemp{num}, int_expr.val);
+  Write_("{} =w copy {}\n", FuncScopeTemp{num}, int_expr.val);
   num_recorder.Record(num);
 }
 
@@ -314,7 +312,7 @@ void QbeIrGenerator::Visit(const FunCallExprNode& call_expr) {
   const auto* id_expr = dynamic_cast<IdExprNode*>((call_expr.func_expr).get());
   assert(id_expr);
   const int res_num = NextLocalNum();
-  WriteOut_("{} =w call ${}()\n", FuncScopeTemp{res_num}, id_expr->id);
+  Write_("{} =w call ${}()\n", FuncScopeTemp{res_num}, id_expr->id);
   num_recorder.Record(res_num);
 }
 
@@ -329,13 +327,13 @@ void QbeIrGenerator::Visit(const UnaryExprNode& unary_expr) {
       const auto arith_op = unary_expr.op == UnaryOperator::kIncr
                                 ? BinaryOperator::kAdd
                                 : BinaryOperator::kSub;
-      WriteOut_("{} =w {} {}, 1\n", FuncScopeTemp{res_num},
-                GetBinaryOperator(arith_op), FuncScopeTemp{expr_num});
+      Write_("{} =w {} {}, 1\n", FuncScopeTemp{res_num},
+             GetBinaryOperator(arith_op), FuncScopeTemp{expr_num});
       const auto* id_expr =
           dynamic_cast<IdExprNode*>((unary_expr.operand).get());
       assert(id_expr);
-      WriteOut_("storew {}, {}\n", FuncScopeTemp{res_num},
-                FuncScopeTemp{id_to_num.at(id_expr->id)});
+      Write_("storew {}, {}\n", FuncScopeTemp{res_num},
+             FuncScopeTemp{id_to_num.at(id_expr->id)});
       num_recorder.Record(res_num);
     } break;
     case UnaryOperator::kPos:
@@ -344,8 +342,7 @@ void QbeIrGenerator::Visit(const UnaryExprNode& unary_expr) {
     case UnaryOperator::kNeg: {
       const int expr_num = num_recorder.NumOfPrevExpr();
       const int res_num = NextLocalNum();
-      WriteOut_("{} =w neg {}\n", FuncScopeTemp{res_num},
-                FuncScopeTemp{expr_num});
+      Write_("{} =w neg {}\n", FuncScopeTemp{res_num}, FuncScopeTemp{expr_num});
       num_recorder.Record(res_num);
     } break;
     case UnaryOperator::kNot: {
@@ -354,17 +351,16 @@ void QbeIrGenerator::Visit(const UnaryExprNode& unary_expr) {
       // The expression !E is equivalent to (0 == E).
       const int expr_num = num_recorder.NumOfPrevExpr();
       const int res_num = NextLocalNum();
-      WriteOut_("{} =w {} {}, 0\n", FuncScopeTemp{res_num},
-                GetBinaryOperator(BinaryOperator::kEq),
-                FuncScopeTemp{expr_num});
+      Write_("{} =w {} {}, 0\n", FuncScopeTemp{res_num},
+             GetBinaryOperator(BinaryOperator::kEq), FuncScopeTemp{expr_num});
       num_recorder.Record(res_num);
     } break;
     case UnaryOperator::kBitComp: {
       const int expr_num = num_recorder.NumOfPrevExpr();
       const int res_num = NextLocalNum();
       // Exclusive or with all ones to flip the bits.
-      WriteOut_("{} =w xor {}, -1\n", FuncScopeTemp{res_num},
-                FuncScopeTemp{expr_num});
+      Write_("{} =w xor {}, -1\n", FuncScopeTemp{res_num},
+             FuncScopeTemp{expr_num});
       num_recorder.Record(res_num);
     } break;
     default:
@@ -381,21 +377,20 @@ void QbeIrGenerator::Visit(const BinaryExprNode& bin_expr) {
   // TODO: use the correct instruction for specific data type:
   // 1. signed or unsigned: currently only supports signed integers.
   // 2. QBE base data type 'w' | 'l' | 's' | 'd': currently only supports 'w'.
-  WriteOut_("{} =w {} {}, {}\n", FuncScopeTemp{num},
-            GetBinaryOperator(bin_expr.op), FuncScopeTemp{left_num},
-            FuncScopeTemp{right_num});
+  Write_("{} =w {} {}, {}\n", FuncScopeTemp{num},
+         GetBinaryOperator(bin_expr.op), FuncScopeTemp{left_num},
+         FuncScopeTemp{right_num});
   num_recorder.Record(num);
 }
 
 void QbeIrGenerator::Visit(const SimpleAssignmentExprNode& assign_expr) {
   assign_expr.expr->Accept(*this);
   int expr_num = num_recorder.NumOfPrevExpr();
-  WriteOut_("storew {}, {}\n", FuncScopeTemp{expr_num},
-            FuncScopeTemp{id_to_num.at(assign_expr.id)});
+  Write_("storew {}, {}\n", FuncScopeTemp{expr_num},
+         FuncScopeTemp{id_to_num.at(assign_expr.id)});
   num_recorder.Record(expr_num);
 }
 
-void QbeIrGenerator::VWriteOut_(fmt::string_view format,
-                                fmt::format_args args) {
+void QbeIrGenerator::VWrite_(fmt::string_view format, fmt::format_args args) {
   fmt::vprint(output_, format, args);
 }


### PR DESCRIPTION
Two functions have been added to implement the indentation logic for labels and instructions, respectively. The pure `Write` function is retained for manual formatting purposes.

Every instruction should be indented by one level; label definitions and comments should not be indented.

> [!important]
> For future QBE IR generation, utilize `WriteLabel_` to write label definitions and `WriteInstr_` to write instructions. Both functions generate a single line, eliminating the need to manually add newline characters (`\n`) to your `format` calls. When writing parts of an instruction or multiple instructions, use `Write_` and remember to prepend each instruction with `kIndentStr` and enclose them with newlines.

Resolves: #99 