### PR TITLE
Enable include cleaner of clang tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,6 +22,7 @@ Checks: >
   modernize-*,
   -modernize-use-trailing-return-type,
   -modernize-use-nodiscard,
+  misc-include-cleaner,
   readability-braces-around-statements,
   readability-function-size,
   readability-identifier-naming,

--- a/include/qbe/sigil.hpp
+++ b/include/qbe/sigil.hpp
@@ -6,7 +6,6 @@
 
 #include <string>
 #include <string_view>
-#include <utility>
 #include <variant>
 
 namespace qbe {

--- a/src/ast_dumper.cpp
+++ b/src/ast_dumper.cpp
@@ -6,8 +6,8 @@
 #include <variant>
 
 #include "ast.hpp"
+#include "operator.hpp"
 #include "type.hpp"
-#include "visitor.hpp"
 
 namespace {
 

--- a/src/qbe_ir_generator.cpp
+++ b/src/qbe_ir_generator.cpp
@@ -1,17 +1,19 @@
 #include "qbe_ir_generator.hpp"
 
+#include <fmt/core.h>
 #include <fmt/ostream.h>
 
 #include <cassert>
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <variant>
+#include <vector>
 
 #include "ast.hpp"
 #include "operator.hpp"
 #include "qbe/sigil.hpp"
-#include "visitor.hpp"
 
 using namespace qbe;
 

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -4,10 +4,13 @@
 #include <cassert>
 #include <cstdint>
 #include <memory>
+#include <utility>
 #include <variant>
 #include <vector>
 
 #include "ast.hpp"
+#include "symbol.hpp"
+#include "type.hpp"
 
 namespace {
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,6 +1,5 @@
 #include "util.hpp"
 
-#include <cstddef>
 #include <string>
 
 std::string Indenter::Indent() const {


### PR DESCRIPTION
Occasionally, we may forget to include necessary headers or remove unnecessary ones. Enabling the include cleaner of clang tidy helps address this issue automatically.