### PR TITLE
Use visit for loop initiate node

### DIFF
--- a/src/ast_dumper.cpp
+++ b/src/ast_dumper.cpp
@@ -86,11 +86,8 @@ void AstDumper::Visit(const FuncDefNode& func_def) {
 void AstDumper::Visit(const LoopInitNode& loop_init) {
   std::cout << indenter_.Indent() << "LoopInitNode\n";
   indenter_.IncreaseLevel();
-  if (std::holds_alternative<std::unique_ptr<DeclNode>>(loop_init.clause)) {
-    std::get<std::unique_ptr<DeclNode>>(loop_init.clause)->Accept(*this);
-  } else {
-    std::get<std::unique_ptr<ExprNode>>(loop_init.clause)->Accept(*this);
-  }
+  std::visit([this](auto&& clause) { clause->Accept(*this); },
+             loop_init.clause);
   indenter_.DecreaseLevel();
 }
 

--- a/src/qbe_ir_generator.cpp
+++ b/src/qbe_ir_generator.cpp
@@ -136,11 +136,8 @@ void QbeIrGenerator::Visit(const FuncDefNode& func_def) {
 }
 
 void QbeIrGenerator::Visit(const LoopInitNode& loop_init) {
-  if (std::holds_alternative<std::unique_ptr<DeclNode>>(loop_init.clause)) {
-    std::get<std::unique_ptr<DeclNode>>(loop_init.clause)->Accept(*this);
-  } else {
-    std::get<std::unique_ptr<ExprNode>>(loop_init.clause)->Accept(*this);
-  }
+  std::visit([this](auto&& clause) { clause->Accept(*this); },
+             loop_init.clause);
 }
 
 void QbeIrGenerator::Visit(const CompoundStmtNode& compound_stmt) {


### PR DESCRIPTION
Make code consistent across all visiting nodes, using `std::visit` for `loop_init_node`.