### PR TITLE
Move parameter generations to its visit function

### DIFF
--- a/include/qbe_ir_generator.hpp
+++ b/include/qbe_ir_generator.hpp
@@ -76,6 +76,11 @@ class QbeIrGenerator : public NonModifyingVisitor {
 
   /// @note This function is not meant to be used directly.
   void VWrite_(fmt::string_view format, fmt::format_args args);
+
+  /// @brief Called by the code generation of `FuncDefNode` to allocate memory
+  /// for the parameters. The value of the parameters are stored in their
+  /// corresponding memory locations.
+  void AllocMemForParams_(const std::vector<std::unique_ptr<ParamNode>>&);
 };
 
 #endif  // QBE_IR_GENERATOR_HPP_


### PR DESCRIPTION
Handling the type and format of parameters should be done in the visit function of `ParamNode` rather than within `FuncDefNode`. This approach groups the logic more clearly and provides a clear indication of where to find related code.
Ideally, code generation related to a specific AST node should be performed within its visit function. Only in rare cases where information from the top level is required should generation be handled at a higher level.

Additionally, function definitions, whether with or without parameters, can be handled uniformly. The for loop simply does nothing if the parameter list is empty.