### PR TITLE
Fix Turnt not running in parallel when `-j` option is passed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,6 @@ LEX = lex
 YACC = bison
 # -d: generate header with default name
 YFLAGS = --verbose --debug -d -Wcounterexamples -Wall
-# Check if -j multiple jobs is configured.
-PARALLEL = false
-ifneq (,$(findstring j,$(MAKEFLAGS)))
-	PARALLEL := true
-endif
-# Export variable to be visible for test/Makefile.
-export PARALLEL
 
 # The Flex or Bison-generated files are not included.
 SRC := $(shell find src/ -name "*.cpp") main.cpp
@@ -31,9 +24,7 @@ DEPS = $(OBJS:.o=.d)
 all: $(TARGET)
 
 test: $(TARGET)
-	# Flags are omitted to prevent passing the -j option since Turnt, our testing tool,
-	# has its own mechanism for parallel builds.
-	cd test/ && $(MAKE) test MAKEFLAGS=
+	$(MAKE) -C test/ test
 
 $(TARGET): $(OBJS)
 	$(CXX) $(CXXFLAGS) $(OBJS) -o $@ $(LDLIBS)

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,12 +1,17 @@
-TURNTFLAGS = --diff
-ifeq (true, $(PARALLEL))
-	TURNTFLAGS += -j
-endif
-
 .PHONY: test clean
 
 test:
-	turnt **/*.c $(TURNTFLAGS)
+	@# NOTE: The -j option is added to MAKEFLAGS only when entering the recipe.
+	@# Therefore, we have to check it here.
+	@case "$(MAKEFLAGS)" in \
+		*j*) \
+			turnt **/*.c --diff -j; \
+			;; \
+		*) \
+			turnt **/*.c --diff; \
+			;; \
+	esac
+
 
 clean:
 	rm -f *.s **/*.s *.o **/*.o *.ssa **/*.ssa


### PR DESCRIPTION
Originally, our test tool, _Turnt_, didn't run in parallel even when the `-j` option was passed as a command line argument to `make test -j`. This was because the `MAKEFLAGS` variable never contained the `-j` option when checked. Based on my experimentation, it seems that the `-j` option is only added to the `MAKEFLAGS` after entering the recipe if it exists. Therefore, we need to check whether the `-j` option is passed inside the recipe. This also prevents the check from polluting the Makefile, as the variable `PARALLEL` is only used by the `test` target.

Additionally, I moved the checking logic down to the Makefile under `test/`. It is more suitable for such a Makefile to know how _Turnt_ works.