### PR TITLE
Support basic pointer features

### DIFF
--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -55,6 +55,8 @@ struct StmtNode : public AstNode {
 struct ExprNode  // NOLINT(cppcoreguidelines-special-member-functions)
     : public AstNode {
   ExprType type = ExprType::kUnknown;
+  bool is_pointer = false;
+
   void Accept(NonModifyingVisitor&) const override;
   void Accept(ModifyingVisitor&) override;
 
@@ -63,26 +65,32 @@ struct ExprNode  // NOLINT(cppcoreguidelines-special-member-functions)
 };
 
 struct DeclNode : public AstNode {
-  DeclNode(std::string id, ExprType decl_type,
+  DeclNode(std::string id, ExprType decl_type, bool is_pointer = false,
            std::unique_ptr<ExprNode> init = {})
-      : id{std::move(id)}, type{decl_type}, init{std::move(init)} {}
+      : id{std::move(id)},
+        type{decl_type},
+        is_pointer{is_pointer},
+        init{std::move(init)} {}
 
   void Accept(NonModifyingVisitor&) const override;
   void Accept(ModifyingVisitor&) override;
 
   std::string id;
   ExprType type;
+  bool is_pointer;
   std::unique_ptr<ExprNode> init;
 };
 
 struct ParamNode : public AstNode {
-  ParamNode(std::string id, ExprType type) : id{std::move(id)}, type{type} {}
+  ParamNode(std::string id, ExprType type, bool is_pointer = false)
+      : id{std::move(id)}, type{type}, is_pointer{is_pointer} {}
 
   void Accept(NonModifyingVisitor&) const override;
   void Accept(ModifyingVisitor&) override;
 
   std::string id;
   ExprType type;
+  bool is_pointer;
 };
 
 struct FuncDefNode : public AstNode {

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -54,53 +54,45 @@ struct StmtNode : public AstNode {
 /// @note This is an abstract class.
 struct ExprNode  // NOLINT(cppcoreguidelines-special-member-functions)
     : public AstNode {
-  ExprType type = ExprType::kUnknown;
-  bool is_pointer = false;
-
   void Accept(NonModifyingVisitor&) const override;
   void Accept(ModifyingVisitor&) override;
 
   /// @note To make the class abstract.
   ~ExprNode() override = 0;
+
+  Type type = Type{};
 };
 
 struct DeclNode : public AstNode {
-  DeclNode(std::string id, ExprType decl_type, bool is_pointer = false,
-           std::unique_ptr<ExprNode> init = {})
-      : id{std::move(id)},
-        type{decl_type},
-        is_pointer{is_pointer},
-        init{std::move(init)} {}
+  DeclNode(std::string id, Type type, std::unique_ptr<ExprNode> init = {})
+      : id{std::move(id)}, type{type}, init{std::move(init)} {}
 
   void Accept(NonModifyingVisitor&) const override;
   void Accept(ModifyingVisitor&) override;
 
   std::string id;
-  ExprType type;
-  bool is_pointer;
+  Type type;
   std::unique_ptr<ExprNode> init;
 };
 
 struct ParamNode : public AstNode {
-  ParamNode(std::string id, ExprType type, bool is_pointer = false)
-      : id{std::move(id)}, type{type}, is_pointer{is_pointer} {}
+  ParamNode(std::string id, Type type) : id{std::move(id)}, type{type} {}
 
   void Accept(NonModifyingVisitor&) const override;
   void Accept(ModifyingVisitor&) override;
 
   std::string id;
-  ExprType type;
-  bool is_pointer;
+  Type type;
 };
 
 struct FuncDefNode : public AstNode {
   FuncDefNode(std::string id,
               std::vector<std::unique_ptr<ParamNode>> parameters,
-              std::unique_ptr<CompoundStmtNode> body, ExprType return_type)
+              std::unique_ptr<CompoundStmtNode> body, Type type)
       : id{std::move(id)},
         parameters{std::move(parameters)},
         body{std::move(body)},
-        return_type{return_type} {}
+        type{type} {}
 
   void Accept(NonModifyingVisitor&) const override;
   void Accept(ModifyingVisitor&) override;
@@ -108,7 +100,7 @@ struct FuncDefNode : public AstNode {
   std::string id;
   std::vector<std::unique_ptr<ParamNode>> parameters;
   std::unique_ptr<CompoundStmtNode> body;
-  ExprType return_type;
+  Type type;
 };
 
 /// @brief A loop initialization can be either a declaration or an expression.

--- a/include/symbol.hpp
+++ b/include/symbol.hpp
@@ -9,22 +9,13 @@
 
 #include "type.hpp"
 
-struct ParamType {
-  ExprType type;
-  bool is_pointer = false;
-
-  ParamType(ExprType type, bool is_pointer = false)
-      : type{type}, is_pointer{is_pointer} {}
-};
-
 struct SymbolEntry {
   std::string id;
-  ExprType expr_type{ExprType::kUnknown};
-  bool is_pointer = false;
-  std::vector<std::unique_ptr<ParamType>> param_types{};
+  Type expr_type;
+  std::vector<Type> param_types{};
 
-  SymbolEntry(std::string id, bool is_pointer = false)
-      : id{std::move(id)}, is_pointer{is_pointer} {}
+  SymbolEntry(std::string id, Type expr_type)
+      : id{std::move(id)}, expr_type{expr_type} {}
 };
 
 class SymbolTable {

--- a/include/symbol.hpp
+++ b/include/symbol.hpp
@@ -9,12 +9,22 @@
 
 #include "type.hpp"
 
+struct ParamType {
+  ExprType type;
+  bool is_pointer = false;
+
+  ParamType(ExprType type, bool is_pointer = false)
+      : type{type}, is_pointer{is_pointer} {}
+};
+
 struct SymbolEntry {
   std::string id;
   ExprType expr_type{ExprType::kUnknown};
-  std::vector<ExprType> param_types{};
+  bool is_pointer = false;
+  std::vector<std::unique_ptr<ParamType>> param_types{};
 
-  SymbolEntry(std::string id) : id{std::move(id)} {}
+  SymbolEntry(std::string id, bool is_pointer = false)
+      : id{std::move(id)}, is_pointer{is_pointer} {}
 };
 
 class SymbolTable {

--- a/include/type.hpp
+++ b/include/type.hpp
@@ -6,11 +6,26 @@
 
 /// @note C has a lots of primitive type. We might need to use classes to
 /// implement type coercion rules.
-enum class ExprType : std::uint8_t {
+enum class PrimitiveType : std::uint8_t {
   kUnknown = 0,  // HACK: default initialized to 0 -> unknown
   kInt,
 };
 
-std::string ExprTypeToString(ExprType type);
+struct Type {
+  Type(PrimitiveType prim_type = PrimitiveType::kUnknown, bool is_ptr = false)
+      : prim_type{prim_type}, is_ptr{is_ptr} {};
+
+  bool operator==(const Type& that) const noexcept {
+    return prim_type == that.prim_type && is_ptr == that.is_ptr;
+  }
+  bool operator!=(const Type& that) const noexcept {
+    return !operator==(that);
+  }
+
+  PrimitiveType prim_type;
+  bool is_ptr;
+};
+
+std::string TypeToString(Type type);
 
 #endif  // TYPE_HPP_

--- a/parser.y
+++ b/parser.y
@@ -64,7 +64,7 @@
 %token INCR DECR
 %token EOF 0
 
-%nterm <ExprType> type_specifier
+%nterm <Type> type_specifier
 %nterm <std::unique_ptr<ExprNode>> expr
 %nterm <std::unique_ptr<ExprNode>> expr_opt
 %nterm <std::unique_ptr<ExprNode>> unary_expr
@@ -124,7 +124,6 @@ func_def_list_opt: func_def_list_opt func_def {
   | epsilon { $$ = std::vector<std::unique_ptr<FuncDefNode>>{}; }
   ;
 
-// TODO: support function pointer
 func_def: type_specifier ID '(' parameter_list_opt ')' compound_stmt {
     $$ = std::make_unique<FuncDefNode>($2, $4, $6, $1);
   }
@@ -145,8 +144,9 @@ parameter_list: parameter_list ',' parameter {
   }
   ;
 
-parameter: type_specifier ID { $$ = std::make_unique<ParamNode>($2, $1); }
-  | type_specifier '*' ID { $$ = std::make_unique<ParamNode>($3, $1, true); }
+parameter: type_specifier ID {
+    $$ = std::make_unique<ParamNode>($2, $1);
+  }
   ;
 
   /* 6.8.2 Compound statement */
@@ -177,9 +177,7 @@ block_item: decl { $$ = $1; }
   ;
 
 decl: type_specifier ID ';' { $$ = std::make_unique<DeclNode>($2, $1); }
-    | type_specifier ID '=' expr ';' { $$ = std::make_unique<DeclNode>($2, $1, false, $4); }
-    | type_specifier '*' ID ';' { $$ = std::make_unique<DeclNode>($3, $1, true); }
-    | type_specifier '*' ID '=' expr ';' { $$ = std::make_unique<DeclNode>($3, $1, true, $5); }
+    | type_specifier ID '=' expr ';' { $$ = std::make_unique<DeclNode>($2, $1, $4); }
     ;
 
 stmt: expr_opt ';' { $$ = std::make_unique<ExprStmtNode>($1); }
@@ -287,9 +285,9 @@ primary_expr: ID { $$ = std::make_unique<IdExprNode>($1); }
 
 /* 6.7.2 Type specifiers */
 /* TODO: support multiple data types */
-type_specifier: INT {
-    $$ = ExprType::kInt;
-  }
+/* TODO: support pointer to pointer */
+type_specifier: INT { $$ = Type{PrimitiveType::kInt}; }
+  | INT '*' { $$ = Type{PrimitiveType::kInt, true}; }
   ;
 
 epsilon: %empty;

--- a/parser.y
+++ b/parser.y
@@ -124,6 +124,7 @@ func_def_list_opt: func_def_list_opt func_def {
   | epsilon { $$ = std::vector<std::unique_ptr<FuncDefNode>>{}; }
   ;
 
+// TODO: support function pointer
 func_def: type_specifier ID '(' parameter_list_opt ')' compound_stmt {
     $$ = std::make_unique<FuncDefNode>($2, $4, $6, $1);
   }
@@ -144,9 +145,8 @@ parameter_list: parameter_list ',' parameter {
   }
   ;
 
-parameter: type_specifier ID {
-    $$ = std::make_unique<ParamNode>($2, $1);
-  }
+parameter: type_specifier ID { $$ = std::make_unique<ParamNode>($2, $1); }
+  | type_specifier '*' ID { $$ = std::make_unique<ParamNode>($3, $1, true); }
   ;
 
   /* 6.8.2 Compound statement */
@@ -177,7 +177,9 @@ block_item: decl { $$ = $1; }
   ;
 
 decl: type_specifier ID ';' { $$ = std::make_unique<DeclNode>($2, $1); }
-    | type_specifier ID '=' expr ';' { $$ = std::make_unique<DeclNode>($2, $1, $4); }
+    | type_specifier ID '=' expr ';' { $$ = std::make_unique<DeclNode>($2, $1, false, $4); }
+    | type_specifier '*' ID ';' { $$ = std::make_unique<DeclNode>($3, $1, true); }
+    | type_specifier '*' ID '=' expr ';' { $$ = std::make_unique<DeclNode>($3, $1, true, $5); }
     ;
 
 stmt: expr_opt ';' { $$ = std::make_unique<ExprStmtNode>($1); }

--- a/src/ast_dumper.cpp
+++ b/src/ast_dumper.cpp
@@ -67,7 +67,12 @@ std::string GetUnaryOperator(UnaryOperator op) {
 
 void AstDumper::Visit(const DeclNode& decl) {
   std::cout << indenter_.Indent() << "DeclNode " << decl.id << ": "
-            << ExprTypeToString(decl.type) << '\n';
+            << ExprTypeToString(decl.type);
+  if (decl.is_pointer) {
+    std::cout << " *";
+  }
+
+  std::cout << '\n';
   if (decl.init) {
     indenter_.IncreaseLevel();
     decl.init->Accept(*this);
@@ -77,7 +82,11 @@ void AstDumper::Visit(const DeclNode& decl) {
 
 void AstDumper::Visit(const ParamNode& parameter) {
   std::cout << indenter_.Indent() << "ParamNode " << parameter.id << ": "
-            << ExprTypeToString(parameter.type) << '\n';
+            << ExprTypeToString(parameter.type);
+  if (parameter.is_pointer) {
+    std::cout << " *";
+  }
+  std::cout << '\n';
 }
 
 void AstDumper::Visit(const FuncDefNode& func_def) {
@@ -223,7 +232,11 @@ void AstDumper::Visit(const NullExprNode& null_expr) {
 
 void AstDumper::Visit(const IdExprNode& id_expr) {
   std::cout << indenter_.Indent() << "IdExprNode " << id_expr.id << ": "
-            << ExprTypeToString(id_expr.type) << '\n';
+            << ExprTypeToString(id_expr.type);
+  if (id_expr.is_pointer) {
+    std::cout << " *";
+  }
+  std::cout << '\n';
 }
 
 void AstDumper::Visit(const IntConstExprNode& int_expr) {
@@ -233,7 +246,11 @@ void AstDumper::Visit(const IntConstExprNode& int_expr) {
 
 void AstDumper::Visit(const ArgExprNode& arg_expr) {
   std::cout << indenter_.Indent() << "ArgExprNode "
-            << ExprTypeToString(arg_expr.type) << '\n';
+            << ExprTypeToString(arg_expr.type);
+  if (arg_expr.is_pointer) {
+    std::cout << " *";
+  }
+  std::cout << '\n';
   indenter_.IncreaseLevel();
   arg_expr.arg->Accept(*this);
   indenter_.DecreaseLevel();

--- a/src/ast_dumper.cpp
+++ b/src/ast_dumper.cpp
@@ -67,12 +67,8 @@ std::string GetUnaryOperator(UnaryOperator op) {
 
 void AstDumper::Visit(const DeclNode& decl) {
   std::cout << indenter_.Indent() << "DeclNode " << decl.id << ": "
-            << ExprTypeToString(decl.type);
-  if (decl.is_pointer) {
-    std::cout << " *";
-  }
+            << TypeToString(decl.type) << '\n';
 
-  std::cout << '\n';
   if (decl.init) {
     indenter_.IncreaseLevel();
     decl.init->Accept(*this);
@@ -82,16 +78,13 @@ void AstDumper::Visit(const DeclNode& decl) {
 
 void AstDumper::Visit(const ParamNode& parameter) {
   std::cout << indenter_.Indent() << "ParamNode " << parameter.id << ": "
-            << ExprTypeToString(parameter.type);
-  if (parameter.is_pointer) {
-    std::cout << " *";
-  }
-  std::cout << '\n';
+            << TypeToString(parameter.type) << '\n';
 }
 
 void AstDumper::Visit(const FuncDefNode& func_def) {
   std::cout << indenter_.Indent() << "FuncDefNode " << func_def.id << ": "
-            << ExprTypeToString(func_def.return_type) << '\n';
+            << TypeToString(func_def.type) << '\n';
+
   indenter_.IncreaseLevel();
   for (const auto& parameter : func_def.parameters) {
     parameter->Accept(*this);
@@ -232,25 +225,17 @@ void AstDumper::Visit(const NullExprNode& null_expr) {
 
 void AstDumper::Visit(const IdExprNode& id_expr) {
   std::cout << indenter_.Indent() << "IdExprNode " << id_expr.id << ": "
-            << ExprTypeToString(id_expr.type);
-  if (id_expr.is_pointer) {
-    std::cout << " *";
-  }
-  std::cout << '\n';
+            << TypeToString(id_expr.type) << '\n';
 }
 
 void AstDumper::Visit(const IntConstExprNode& int_expr) {
   std::cout << indenter_.Indent() << "IntConstExprNode " << int_expr.val << ": "
-            << ExprTypeToString(int_expr.type) << '\n';
+            << TypeToString(int_expr.type) << '\n';
 }
 
 void AstDumper::Visit(const ArgExprNode& arg_expr) {
   std::cout << indenter_.Indent() << "ArgExprNode "
-            << ExprTypeToString(arg_expr.type);
-  if (arg_expr.is_pointer) {
-    std::cout << " *";
-  }
-  std::cout << '\n';
+            << TypeToString(arg_expr.type) << '\n';
   indenter_.IncreaseLevel();
   arg_expr.arg->Accept(*this);
   indenter_.DecreaseLevel();
@@ -258,7 +243,7 @@ void AstDumper::Visit(const ArgExprNode& arg_expr) {
 
 void AstDumper::Visit(const FuncCallExprNode& call_expr) {
   std::cout << indenter_.Indent() << "FuncCallExprNode "
-            << ExprTypeToString(call_expr.type) << '\n';
+            << TypeToString(call_expr.type) << '\n';
   indenter_.IncreaseLevel();
   call_expr.func_expr->Accept(*this);
   for (const auto& arg : call_expr.args) {
@@ -269,7 +254,7 @@ void AstDumper::Visit(const FuncCallExprNode& call_expr) {
 
 void AstDumper::Visit(const UnaryExprNode& unary_expr) {
   std::cout << indenter_.Indent() << "UnaryExprNode "
-            << ExprTypeToString(unary_expr.type) << " "
+            << TypeToString(unary_expr.type) << " "
             << GetUnaryOperator(unary_expr.op) << '\n';
   indenter_.IncreaseLevel();
   unary_expr.operand->Accept(*this);
@@ -278,7 +263,7 @@ void AstDumper::Visit(const UnaryExprNode& unary_expr) {
 
 void AstDumper::Visit(const BinaryExprNode& bin_expr) {
   std::cout << indenter_.Indent() << "BinaryExprNode "
-            << ExprTypeToString(bin_expr.type) << " "
+            << TypeToString(bin_expr.type) << " "
             << GetBinaryOperator(bin_expr.op) << '\n';
   indenter_.IncreaseLevel();
   bin_expr.lhs->Accept(*this);
@@ -288,10 +273,10 @@ void AstDumper::Visit(const BinaryExprNode& bin_expr) {
 
 void AstDumper::Visit(const SimpleAssignmentExprNode& assign_expr) {
   std::cout << indenter_.Indent() << "SimpleAssignmentExprNode "
-            << ExprTypeToString(assign_expr.expr->type) << '\n';
+            << TypeToString(assign_expr.expr->type) << '\n';
   indenter_.IncreaseLevel();
   std::cout << indenter_.Indent() << assign_expr.id << ": "
-            << ExprTypeToString(assign_expr.type) << '\n';
+            << TypeToString(assign_expr.type) << '\n';
   assign_expr.expr->Accept(*this);
   indenter_.DecreaseLevel();
 }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -2,12 +2,20 @@
 
 #include <string>
 
-std::string ExprTypeToString(ExprType type) {
-  switch (type) {
-    case ExprType::kInt:
-      return "int";
-    case ExprType::kUnknown:
+std::string TypeToString(Type type) {
+  std::string out = "";
+  switch (type.prim_type) {
+    case PrimitiveType::kInt:
+      out.append("int");
+      break;
+    case PrimitiveType::kUnknown:
     default:
-      return "unknown";
+      out.append("unknown");
   }
+
+  if (type.is_ptr) {
+    out.append("*");
+  }
+
+  return out;
 }

--- a/test/typecheck/pointer.c
+++ b/test/typecheck/pointer.c
@@ -2,6 +2,7 @@ int main() {
   int a = 10;
   int* b;
   int* c = &a;
+  b = c;
 
   return *c;
 }

--- a/test/typecheck/pointer.c
+++ b/test/typecheck/pointer.c
@@ -1,0 +1,7 @@
+int main() {
+  int a = 10;
+  int* b;
+  int* c = &a;
+
+  return *c;
+}

--- a/test/typecheck/pointer.exp
+++ b/test/typecheck/pointer.exp
@@ -1,0 +1,12 @@
+ProgramNode
+  FuncDefNode main: int
+    CompoundStmtNode
+      DeclNode a: int
+        IntConstExprNode 10: int
+      DeclNode b: int *
+      DeclNode c: int *
+        UnaryExprNode int &
+          IdExprNode a: int
+      ReturnStmtNode
+        UnaryExprNode int *
+          IdExprNode c: int *

--- a/test/typecheck/pointer.exp
+++ b/test/typecheck/pointer.exp
@@ -3,10 +3,14 @@ ProgramNode
     CompoundStmtNode
       DeclNode a: int
         IntConstExprNode 10: int
-      DeclNode b: int *
-      DeclNode c: int *
-        UnaryExprNode int &
+      DeclNode b: int*
+      DeclNode c: int*
+        UnaryExprNode int* &
           IdExprNode a: int
+      ExprStmtNode
+        SimpleAssignmentExprNode int*
+          b: int*
+          IdExprNode c: int*
       ReturnStmtNode
         UnaryExprNode int *
-          IdExprNode c: int *
+          IdExprNode c: int*

--- a/test/typecheck/pointer_param.c
+++ b/test/typecheck/pointer_param.c
@@ -1,0 +1,10 @@
+int add(int* x, int* y) {
+  return *x + *y;
+}
+
+int main() {
+  int a = 3;
+  int b = 5;
+  int* c = &b;
+  return add(&a, c);
+}

--- a/test/typecheck/pointer_param.exp
+++ b/test/typecheck/pointer_param.exp
@@ -1,28 +1,28 @@
 ProgramNode
   FuncDefNode add: int
-    ParamNode x: int *
-    ParamNode y: int *
+    ParamNode x: int*
+    ParamNode y: int*
     CompoundStmtNode
       ReturnStmtNode
         BinaryExprNode int +
           UnaryExprNode int *
-            IdExprNode x: int *
+            IdExprNode x: int*
           UnaryExprNode int *
-            IdExprNode y: int *
+            IdExprNode y: int*
   FuncDefNode main: int
     CompoundStmtNode
       DeclNode a: int
         IntConstExprNode 3: int
       DeclNode b: int
         IntConstExprNode 5: int
-      DeclNode c: int *
-        UnaryExprNode int &
+      DeclNode c: int*
+        UnaryExprNode int* &
           IdExprNode b: int
       ReturnStmtNode
         FuncCallExprNode int
           IdExprNode add: int
-          ArgExprNode int *
-            UnaryExprNode int &
+          ArgExprNode int*
+            UnaryExprNode int* &
               IdExprNode a: int
-          ArgExprNode int *
-            IdExprNode c: int *
+          ArgExprNode int*
+            IdExprNode c: int*

--- a/test/typecheck/pointer_param.exp
+++ b/test/typecheck/pointer_param.exp
@@ -1,0 +1,28 @@
+ProgramNode
+  FuncDefNode add: int
+    ParamNode x: int *
+    ParamNode y: int *
+    CompoundStmtNode
+      ReturnStmtNode
+        BinaryExprNode int +
+          UnaryExprNode int *
+            IdExprNode x: int *
+          UnaryExprNode int *
+            IdExprNode y: int *
+  FuncDefNode main: int
+    CompoundStmtNode
+      DeclNode a: int
+        IntConstExprNode 3: int
+      DeclNode b: int
+        IntConstExprNode 5: int
+      DeclNode c: int *
+        UnaryExprNode int &
+          IdExprNode b: int
+      ReturnStmtNode
+        FuncCallExprNode int
+          IdExprNode add: int
+          ArgExprNode int *
+            UnaryExprNode int &
+              IdExprNode a: int
+          ArgExprNode int *
+            IdExprNode c: int *


### PR DESCRIPTION
This PR includes the following changes:

- Pointer variables declaration
- Function parameters, arguments as pointers
- Check pointer compatibility
- Create Type struct for both `Declnode` and `ExprNode`
- Update default Type for label identifier

Function pointer and pointer to pointer type will be added in future PRs. Also, Function return pointer type may require the feature of `malloc` and `free`, which are not supported yet.

See: #116 