### PR TITLE
Refactor assignment expression

### DIFF
--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -365,14 +365,15 @@ struct AssignmentExprNode  // NOLINT(cppcoreguidelines-special-member-functions)
 };
 
 struct SimpleAssignmentExprNode : public AssignmentExprNode {
-  SimpleAssignmentExprNode(std::string id, std::unique_ptr<ExprNode> expr)
-      : id{std::move(id)}, expr{std::move(expr)} {}
+  SimpleAssignmentExprNode(std::unique_ptr<ExprNode> lhs,
+                           std::unique_ptr<ExprNode> rhs)
+      : lhs{std::move(lhs)}, rhs{std::move(rhs)} {}
 
   void Accept(NonModifyingVisitor&) const override;
   void Accept(ModifyingVisitor&) override;
 
-  std::string id;
-  std::unique_ptr<ExprNode> expr;
+  std::unique_ptr<ExprNode> lhs;
+  std::unique_ptr<ExprNode> rhs;
 };
 
 #endif  // AST_HPP_

--- a/parser.y
+++ b/parser.y
@@ -66,6 +66,7 @@
 
 %nterm <Type> type_specifier
 %nterm <std::unique_ptr<ExprNode>> expr
+%nterm <std::unique_ptr<ExprNode>> assign_expr
 %nterm <std::unique_ptr<ExprNode>> expr_opt
 %nterm <std::unique_ptr<ExprNode>> unary_expr
 %nterm <std::unique_ptr<ExprNode>> postfix_expr
@@ -234,8 +235,14 @@ expr: unary_expr { $$ = $1; }
   /* equality 6.5.9 */
   | expr EQ expr { $$ = std::make_unique<BinaryExprNode>(BinaryOperator::kEq, $1, $3); }
   | expr NE expr { $$ = std::make_unique<BinaryExprNode>(BinaryOperator::kNeq, $1, $3); }
-  /* assignment 6.5.16 */
-  | ID '=' expr { $$ = std::make_unique<SimpleAssignmentExprNode>($1, $3); }
+  | assign_expr { $$ = $1; }
+  ;
+
+/* assignment 6.5.16 */
+/* TODO: support mulitple assignment operators */
+assign_expr: unary_expr '=' expr {
+    $$ = std::make_unique<SimpleAssignmentExprNode>($1, $3);
+  }
   ;
 
 /* 6.5.3 Unary operators */

--- a/src/ast_dumper.cpp
+++ b/src/ast_dumper.cpp
@@ -273,10 +273,9 @@ void AstDumper::Visit(const BinaryExprNode& bin_expr) {
 
 void AstDumper::Visit(const SimpleAssignmentExprNode& assign_expr) {
   std::cout << indenter_.Indent() << "SimpleAssignmentExprNode "
-            << TypeToString(assign_expr.expr->type) << '\n';
-  indenter_.IncreaseLevel();
-  std::cout << indenter_.Indent() << assign_expr.id << ": "
             << TypeToString(assign_expr.type) << '\n';
-  assign_expr.expr->Accept(*this);
+  indenter_.IncreaseLevel();
+  assign_expr.lhs->Accept(*this);
+  assign_expr.rhs->Accept(*this);
   indenter_.DecreaseLevel();
 }

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -301,19 +301,11 @@ void TypeChecker::Visit(BinaryExprNode& bin_expr) {
 }
 
 void TypeChecker::Visit(SimpleAssignmentExprNode& assign_expr) {
-  assign_expr.expr->Accept(*this);
-  if (auto symbol = env_.LookUp(assign_expr.id)) {
-    if (assign_expr.expr->type == symbol->expr_type) {
-      // 6.5.16 Assignment operators
-      // The type of an assignment expression is the type of the left
-      // operand unless the left operand has qualified type, in which case it
-      // is the unqualified version of the type of the left operand.
-      assign_expr.type = symbol->expr_type;
-    } else {
-      // TODO: assigning to 'symbol->expr_type' from incompatible type
-      // 'expr->type'
-    }
+  assign_expr.lhs->Accept(*this);
+  assign_expr.rhs->Accept(*this);
+  if (assign_expr.lhs->type != assign_expr.rhs->type) {
+    // TODO: unmatched assignment type
   } else {
-    // TODO: 'id' undeclared
+    assign_expr.type = assign_expr.rhs->type;
   }
 }

--- a/test/typecheck/assignment_expr.exp
+++ b/test/typecheck/assignment_expr.exp
@@ -4,7 +4,7 @@ ProgramNode
       DeclNode a: int
       ExprStmtNode
         SimpleAssignmentExprNode int
-          a: int
+          IdExprNode a: int
           BinaryExprNode int +
             IntConstExprNode 3: int
             IntConstExprNode 2: int

--- a/test/typecheck/compound_stmt.exp
+++ b/test/typecheck/compound_stmt.exp
@@ -5,7 +5,7 @@ ProgramNode
         IntConstExprNode 1: int
       ExprStmtNode
         SimpleAssignmentExprNode int
-          i: int
+          IdExprNode i: int
           BinaryExprNode int +
             IdExprNode i: int
             IntConstExprNode 1: int

--- a/test/typecheck/continue_stmt.exp
+++ b/test/typecheck/continue_stmt.exp
@@ -12,12 +12,12 @@ ProgramNode
             CompoundStmtNode
               ExprStmtNode
                 SimpleAssignmentExprNode int
-                  a: int
+                  IdExprNode a: int
                   IntConstExprNode 5: int
               ContinueStmtNode
           ExprStmtNode
             SimpleAssignmentExprNode int
-              a: int
+              IdExprNode a: int
               IntConstExprNode 0: int
         // While
         BinaryExprNode int <

--- a/test/typecheck/do_while_single_stmt.exp
+++ b/test/typecheck/do_while_single_stmt.exp
@@ -7,7 +7,7 @@ ProgramNode
         // Do
         ExprStmtNode
           SimpleAssignmentExprNode int
-            i: int
+            IdExprNode i: int
             BinaryExprNode int -
               IdExprNode i: int
               IntConstExprNode 1: int

--- a/test/typecheck/do_while_stmt.exp
+++ b/test/typecheck/do_while_stmt.exp
@@ -8,7 +8,7 @@ ProgramNode
         CompoundStmtNode
           ExprStmtNode
             SimpleAssignmentExprNode int
-              i: int
+              IdExprNode i: int
               BinaryExprNode int +
                 IdExprNode i: int
                 IntConstExprNode 1: int

--- a/test/typecheck/for_nested_stmt.exp
+++ b/test/typecheck/for_nested_stmt.exp
@@ -11,7 +11,7 @@ ProgramNode
           IdExprNode i: int
           IntConstExprNode 5: int
         SimpleAssignmentExprNode int
-          i: int
+          IdExprNode i: int
           BinaryExprNode int +
             IdExprNode i: int
             IntConstExprNode 1: int
@@ -24,14 +24,14 @@ ProgramNode
               IdExprNode j: int
               IntConstExprNode 5: int
             SimpleAssignmentExprNode int
-              j: int
+              IdExprNode j: int
               BinaryExprNode int +
                 IdExprNode j: int
                 IntConstExprNode 1: int
             CompoundStmtNode
               ExprStmtNode
                 SimpleAssignmentExprNode int
-                  k: int
+                  IdExprNode k: int
                   BinaryExprNode int +
                     IdExprNode k: int
                     IntConstExprNode 1: int

--- a/test/typecheck/for_stmt.exp
+++ b/test/typecheck/for_stmt.exp
@@ -7,20 +7,20 @@ ProgramNode
       ForStmtNode
         LoopInitNode
           SimpleAssignmentExprNode int
-            i: int
+            IdExprNode i: int
             IntConstExprNode 0: int
         BinaryExprNode int <
           IdExprNode i: int
           IntConstExprNode 5: int
         SimpleAssignmentExprNode int
-          i: int
+          IdExprNode i: int
           BinaryExprNode int +
             IdExprNode i: int
             IntConstExprNode 1: int
         CompoundStmtNode
           ExprStmtNode
             SimpleAssignmentExprNode int
-              j: int
+              IdExprNode j: int
               BinaryExprNode int +
                 IdExprNode j: int
                 IntConstExprNode 1: int

--- a/test/typecheck/goto_stmt.exp
+++ b/test/typecheck/goto_stmt.exp
@@ -6,7 +6,7 @@ ProgramNode
       IdLabeledStmtNode begin
         ExprStmtNode
           SimpleAssignmentExprNode int
-            i: int
+            IdExprNode i: int
             BinaryExprNode int +
               IdExprNode i: int
               IntConstExprNode 1: int

--- a/test/typecheck/if_else_nested_single_stmt.exp
+++ b/test/typecheck/if_else_nested_single_stmt.exp
@@ -15,17 +15,17 @@ ProgramNode
           // Then
           ExprStmtNode
             SimpleAssignmentExprNode int
-              i: int
+              IdExprNode i: int
               IntConstExprNode 2: int
           // Else
           ExprStmtNode
             SimpleAssignmentExprNode int
-              i: int
+              IdExprNode i: int
               IntConstExprNode 7: int
         // Else
         ExprStmtNode
           SimpleAssignmentExprNode int
-            i: int
+            IdExprNode i: int
             IntConstExprNode 15: int
       ReturnStmtNode
         IdExprNode i: int

--- a/test/typecheck/if_else_nested_stmt.exp
+++ b/test/typecheck/if_else_nested_stmt.exp
@@ -17,13 +17,13 @@ ProgramNode
             CompoundStmtNode
               ExprStmtNode
                 SimpleAssignmentExprNode int
-                  i: int
+                  IdExprNode i: int
                   IntConstExprNode 2: int
             // Else
             CompoundStmtNode
               ExprStmtNode
                 SimpleAssignmentExprNode int
-                  i: int
+                  IdExprNode i: int
                   IntConstExprNode 7: int
         // Else
         CompoundStmtNode
@@ -35,13 +35,13 @@ ProgramNode
             CompoundStmtNode
               ExprStmtNode
                 SimpleAssignmentExprNode int
-                  i: int
+                  IdExprNode i: int
                   IntConstExprNode 30: int
             // Else
             CompoundStmtNode
               ExprStmtNode
                 SimpleAssignmentExprNode int
-                  i: int
+                  IdExprNode i: int
                   IntConstExprNode 15: int
       ReturnStmtNode
         IdExprNode i: int

--- a/test/typecheck/if_else_single_stmt.exp
+++ b/test/typecheck/if_else_single_stmt.exp
@@ -10,14 +10,14 @@ ProgramNode
         // Then
         ExprStmtNode
           SimpleAssignmentExprNode int
-            i: int
+            IdExprNode i: int
             BinaryExprNode int -
               IdExprNode i: int
               IntConstExprNode 1: int
         // Else
         ExprStmtNode
           SimpleAssignmentExprNode int
-            i: int
+            IdExprNode i: int
             BinaryExprNode int +
               IdExprNode i: int
               IntConstExprNode 1: int

--- a/test/typecheck/if_else_stmt.exp
+++ b/test/typecheck/if_else_stmt.exp
@@ -11,13 +11,13 @@ ProgramNode
         CompoundStmtNode
           ExprStmtNode
             SimpleAssignmentExprNode int
-              i: int
+              IdExprNode i: int
               IntConstExprNode 0: int
         // Else
         CompoundStmtNode
           ExprStmtNode
             SimpleAssignmentExprNode int
-              i: int
+              IdExprNode i: int
               BinaryExprNode int +
                 IdExprNode i: int
                 IntConstExprNode 1: int

--- a/test/typecheck/if_single_stmt.exp
+++ b/test/typecheck/if_single_stmt.exp
@@ -10,7 +10,7 @@ ProgramNode
         // Then
         ExprStmtNode
           SimpleAssignmentExprNode int
-            i: int
+            IdExprNode i: int
             BinaryExprNode int +
               IdExprNode i: int
               IntConstExprNode 1: int

--- a/test/typecheck/pointer.c
+++ b/test/typecheck/pointer.c
@@ -3,6 +3,7 @@ int main() {
   int* b;
   int* c = &a;
   b = c;
+  *c = 5;
 
   return *c;
 }

--- a/test/typecheck/pointer.exp
+++ b/test/typecheck/pointer.exp
@@ -9,7 +9,7 @@ ProgramNode
           IdExprNode a: int
       ExprStmtNode
         SimpleAssignmentExprNode int*
-          b: int*
+          IdExprNode b: int*
           IdExprNode c: int*
       ReturnStmtNode
         UnaryExprNode int *

--- a/test/typecheck/pointer.exp
+++ b/test/typecheck/pointer.exp
@@ -11,6 +11,11 @@ ProgramNode
         SimpleAssignmentExprNode int*
           IdExprNode b: int*
           IdExprNode c: int*
+      ExprStmtNode
+        SimpleAssignmentExprNode int
+          UnaryExprNode int *
+            IdExprNode c: int*
+          IntConstExprNode 5: int
       ReturnStmtNode
         UnaryExprNode int *
           IdExprNode c: int*

--- a/test/typecheck/switch_stmt.exp
+++ b/test/typecheck/switch_stmt.exp
@@ -10,20 +10,20 @@ ProgramNode
             IntConstExprNode 1: int
             ExprStmtNode
               SimpleAssignmentExprNode int
-                a: int
+                IdExprNode a: int
                 IntConstExprNode 2: int
           BreakStmtNode
           CaseStmtNode
             IntConstExprNode 2: int
             ExprStmtNode
               SimpleAssignmentExprNode int
-                a: int
+                IdExprNode a: int
                 IntConstExprNode 3: int
           BreakStmtNode
           DefaultStmtNode
             ExprStmtNode
               SimpleAssignmentExprNode int
-                a: int
+                IdExprNode a: int
                 IntConstExprNode 4: int
       ReturnStmtNode
         IdExprNode a: int

--- a/test/typecheck/unary_expr.exp
+++ b/test/typecheck/unary_expr.exp
@@ -11,22 +11,22 @@ ProgramNode
           IdExprNode i: int
       ExprStmtNode
         SimpleAssignmentExprNode int
-          i: int
+          IdExprNode i: int
           UnaryExprNode int +
             IdExprNode i: int
       ExprStmtNode
         SimpleAssignmentExprNode int
-          i: int
+          IdExprNode i: int
           UnaryExprNode int -
             IdExprNode i: int
       ExprStmtNode
         SimpleAssignmentExprNode int
-          i: int
+          IdExprNode i: int
           UnaryExprNode int !
             IdExprNode i: int
       ExprStmtNode
         SimpleAssignmentExprNode int
-          i: int
+          IdExprNode i: int
           UnaryExprNode int ~
             IdExprNode i: int
       ReturnStmtNode

--- a/test/typecheck/while_single_stmt.exp
+++ b/test/typecheck/while_single_stmt.exp
@@ -11,7 +11,7 @@ ProgramNode
         // Body
         ExprStmtNode
           SimpleAssignmentExprNode int
-            i: int
+            IdExprNode i: int
             BinaryExprNode int -
               IdExprNode i: int
               IntConstExprNode 1: int

--- a/test/typecheck/while_stmt.exp
+++ b/test/typecheck/while_stmt.exp
@@ -12,7 +12,7 @@ ProgramNode
         CompoundStmtNode
           ExprStmtNode
             SimpleAssignmentExprNode int
-              i: int
+              IdExprNode i: int
               BinaryExprNode int -
                 IdExprNode i: int
                 IntConstExprNode 1: int


### PR DESCRIPTION
In order to support pointer dereference on the left hand side, such as `*ptr = 10`, this PR introduces assignment expression.

```
(6.5.16) assignment-expression:
  conditional-expression
  unary-expression assignment-operator assignment-expression
```