### PR TITLE
Introduce concept of scope & Check whether label is defined

### DIFF
--- a/include/scope.hpp
+++ b/include/scope.hpp
@@ -36,9 +36,8 @@ struct Scope {
 /// @brief Manages scopes and symbol tables.
 class ScopeStack {
  public:
-  // TODO: Remove default value.
   /// @brief Pushes a new scope of the kind.
-  void PushScope(ScopeKind kind = ScopeKind::kBlock) {
+  void PushScope(ScopeKind kind) {
     scopes_.emplace_back(kind, std::make_unique<SymbolTable>());
   }
 
@@ -48,12 +47,11 @@ class ScopeStack {
     scopes_.pop_back();
   }
 
-  // TODO: Remove default value.
   /// @brief Adds an entry to the top-most scope of the kind.
   /// @throws `NotInScopeError`
   /// @throws `NotInSuchKindOfScopeError`
   std::shared_ptr<SymbolEntry> Add(std::unique_ptr<SymbolEntry> entry,
-                                   ScopeKind kind = ScopeKind::kBlock) {
+                                   ScopeKind kind) {
     ThrowIfNotInScope_();
     for (auto it = scopes_.rbegin(); it != scopes_.rend(); ++it) {
       if (it->kind == kind) {

--- a/include/scope.hpp
+++ b/include/scope.hpp
@@ -1,6 +1,7 @@
 #ifndef SCOPE_HPP_
 #define SCOPE_HPP_
 
+#include <cstdint>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -8,6 +9,20 @@
 #include <vector>
 
 #include "symbol.hpp"
+
+// 6.2.1 Scopes of identifiers
+enum class ScopeKind : std::uint8_t {
+  /// @note A label name is the only kind of identifier that has function scope.
+  kFunc,
+  /// @note Appears outside of any block or list of parameters.
+  kFile,
+  /// @note Appears inside a block or within the list of parameter declarations
+  /// in a function definition.
+  kBlock,
+  /// @note Appears within the list of parameter declarations in a function
+  /// prototype.
+  kParam,
+};
 
 /// @brief Manages scopes and symbol tables.
 class ScopeStack {

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -182,7 +182,8 @@ void TypeChecker::Visit(ReturnStmtNode& ret_stmt) {
 void TypeChecker::Visit(GotoStmtNode& goto_stmt) {
   // NOTE: We can know whether a label is defined until the function is about to
   // end. Thus, it's checked in the function definition.
-  // Also the lookup from the environment is not necessary.
+  // Also the lookup from the environment is not necessary. In fact, labels are
+  // not added to the environment.
   const bool is_not_defined =
       label_defined.find(goto_stmt.label) == label_defined.end() ||
       !label_defined.at(goto_stmt.label);
@@ -229,10 +230,6 @@ void TypeChecker::Visit(SwitchStmtNode& switch_stmt) {
 }
 
 void TypeChecker::Visit(IdLabeledStmtNode& id_labeled_stmt) {
-  // FIXME: Labels have error type.
-  env_.Add(std::make_unique<SymbolEntry>(id_labeled_stmt.label,
-                                         PrimitiveType::kUnknown),
-           ScopeKind::kFunc);
   label_defined[id_labeled_stmt.label] = true;
   id_labeled_stmt.stmt->Accept(*this);
 }

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -230,6 +230,10 @@ void TypeChecker::Visit(SwitchStmtNode& switch_stmt) {
 }
 
 void TypeChecker::Visit(IdLabeledStmtNode& id_labeled_stmt) {
+  if (label_defined.find(id_labeled_stmt.label) != label_defined.end() &&
+      label_defined.at(id_labeled_stmt.label)) {
+    // TODO: redefinition of label 'label'
+  }
   label_defined[id_labeled_stmt.label] = true;
   id_labeled_stmt.stmt->Accept(*this);
 }

--- a/test/typecheck/goto_stmt.c
+++ b/test/typecheck/goto_stmt.c
@@ -1,7 +1,11 @@
 int main() {
   int i = 0;
-begin:
-  i = i + 1;
+  {
+  begin:
+    i = i + 1;
+  }
+  // Since label is of function scope,
+  // it should still be visible here.
   goto begin;
   return 0;
 }

--- a/test/typecheck/goto_stmt.c
+++ b/test/typecheck/goto_stmt.c
@@ -7,5 +7,7 @@ int main() {
   // Since label is of function scope,
   // it should still be visible here.
   goto begin;
+  // Not a redeclaration because their scopes are different.
+  int begin;
   return 0;
 }

--- a/test/typecheck/goto_stmt.exp
+++ b/test/typecheck/goto_stmt.exp
@@ -12,5 +12,6 @@ ProgramNode <1:1>
                 IdExprNode <5:9> i: int
                 IntConstExprNode <5:13> 1: int
       GotoStmtNode <9:3> begin
-      ReturnStmtNode <10:3>
-        IntConstExprNode <10:10> 0: int
+      DeclNode <11:7> begin: int
+      ReturnStmtNode <12:3>
+        IntConstExprNode <12:10> 0: int

--- a/test/typecheck/goto_stmt.exp
+++ b/test/typecheck/goto_stmt.exp
@@ -3,13 +3,14 @@ ProgramNode <1:1>
     CompoundStmtNode <1:12>
       DeclNode <2:7> i: int
         IntConstExprNode <2:11> 0: int
-      IdLabeledStmtNode <3:1> begin
-        ExprStmtNode <4:3>
-          SimpleAssignmentExprNode <4:5> int
-            IdExprNode <4:3> i: int
-            BinaryExprNode <4:9> int +
-              IdExprNode <4:7> i: int
-              IntConstExprNode <4:11> 1: int
-      GotoStmtNode <5:3> begin
-      ReturnStmtNode <6:3>
-        IntConstExprNode <6:10> 0: int
+      CompoundStmtNode <3:3>
+        IdLabeledStmtNode <4:3> begin
+          ExprStmtNode <5:5>
+            SimpleAssignmentExprNode <5:7> int
+              IdExprNode <5:5> i: int
+              BinaryExprNode <5:11> int +
+                IdExprNode <5:9> i: int
+                IntConstExprNode <5:13> 1: int
+      GotoStmtNode <9:3> begin
+      ReturnStmtNode <10:3>
+        IntConstExprNode <10:10> 0: int


### PR DESCRIPTION
- Each scope now associates with a `ScopeKind`. Please refer to _include/scope.hpp_: `struct Scope`.
  - `ScopeStack::PushScope` and `ScopeStack::Add` now require a `ScopeKind`. Modifications have been made in `src/type_checker.cpp` to assign scope kinds to scopes and symbols.

- `ScopeStack` now supports merging the current scope with the next scope. This functionality is implemented in _include/scope.hpp_: `ScopeStack::MergeWithNextScope`.
  - This enhancement specifically addresses including function parameters in the scope of the function body.

- The checking for "Use of undefined label" and "redefinition of label" now utilizes an auxiliary map. This change is implemented in _src/type_checker.cpp_: `<unnamed>::label_defined`.
  - The undefined-check is performed just before the function scope ends.

> [!important]
> Currently, a function scope is opened by a function, but no label is actually added to such a scope (symbol table). This is due to the following reasons:
> 1. Labels reside in their own scope and can only be redefined by labels.
> 2. The redefinition check of a label is performed by looking up the auxiliary map instead of the scope stack. If we were to look up the scope stack, we would need to support looking up a certain kind of scope or a certain kind of symbol, to avoid mistakenly `goto` a variable or assign to a label.
>
> In fact, I also question the usefulness of scope kinds. Although they are defined in the manual, I have yet to discern their semantic differences.
> @leewei05, do you think we should still add the labels into the scope? Or should we ignore the concept of scope kind altogether? Or should we defer this decision and leave the labels as not added?
