### PR TITLE
Record location of AST nodes

### DIFF
--- a/include/location.hpp
+++ b/include/location.hpp
@@ -1,0 +1,17 @@
+#ifndef LOCATION_HPP_
+#define LOCATION_HPP_
+
+#include <ostream>
+
+struct Location {
+  int line;
+  int column;
+};
+
+/// @brief Outputs the location in the format "line:column".
+inline std::ostream& operator<<(std::ostream& os, const Location& loc) {
+  return os << loc.line << ":" << loc.column;
+  ;
+}
+
+#endif /* LOCATION_HPP_ */

--- a/lexer.l
+++ b/lexer.l
@@ -3,23 +3,33 @@
 /* we're not using input & yyunput, don't generate code for them to avoid compiler warnings */
 %option noinput
 %option nounput
-/* automatically track line number */
-%option yylineno
 
 %{
-
-// Give Flex the prototype of yylex we want.
-# define YY_DECL \
-  yy::parser::symbol_type yylex()
 
 #include <cstdlib>
 #include <iostream>
 
 #include "y.tab.hpp"
 
-// Use LINENO for the actual line number in the source code
-// yylineno has advanced to the next line when we reference it.
-#define LINENO (yylineno - 1)
+// Give Flex the prototype of yylex we want.
+# define YY_DECL \
+  yy::parser::symbol_type yylex()
+
+static auto yylloc = yy::location{};
+
+// For more details, see https://stackoverflow.com/a/22125500.
+#define YY_USER_ACTION \
+  yylloc.begin.line = yylloc.end.line; \
+  yylloc.begin.column = yylloc.end.column; \
+  for (auto i = 0; i < yyleng; ++i) { \
+    if (yytext[i] == '\n') { \
+      yylloc.end.line++; \
+      yylloc.end.column = 1; \
+    } else { \
+      yylloc.end.column++; \
+    } \
+  }
+
 %}
 
 /* You can include letters, decimal digits, and the underscore character '_'
@@ -28,55 +38,66 @@
    https://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html#Identifiers */
 identifier [a-zA-Z_][0-9a-zA-Z_]*
 integer [0-9]+
-/* minus sign (-) must be the first or last one since it has special meaning
-   when it's in the middle */
-operator [-+*/%=<>&!~]
-bracket [\(\)\{\}\[\]]
 
 %x C_COMMENT CXX_COMMENT
 
 %%
 
   /* delimiters */
-";" { return yytext[0]; }
-":" { return yytext[0]; }
+";" { return yy::parser::make_SEMICOLON(yylloc); }
+":" { return yy::parser::make_COLON(yylloc); }
 
   /* commas */
-"," { return yytext[0]; }
+"," { return yy::parser::make_COMMA(yylloc); }
 
   /* operators */
-{operator} { return yytext[0]; }
-"--" { return yy::parser::make_DECR(); }
-"++" { return yy::parser::make_INCR(); }
-"==" { return yy::parser::make_EQ(); }
-"!=" { return yy::parser::make_NE(); }
-"<=" { return yy::parser::make_LE(); }
-">=" { return yy::parser::make_GE(); }
+"-" { return yy::parser::make_MINUS(yylloc); }
+"+" { return yy::parser::make_PLUS(yylloc); }
+"*" { return yy::parser::make_STAR(yylloc); }
+"/" { return yy::parser::make_DIV(yylloc); }
+"%" { return yy::parser::make_MOD(yylloc); }
+"&" { return yy::parser::make_AMPERSAND(yylloc); }
+"!" { return yy::parser::make_EXCLAMATION(yylloc); }
+"~" { return yy::parser::make_TILDE(yylloc); }
+"=" { return yy::parser::make_ASSIGN(yylloc); }
+"<" { return yy::parser::make_LT(yylloc); }
+">" { return yy::parser::make_GT(yylloc); }
+"--" { return yy::parser::make_DECR(yylloc); }
+"++" { return yy::parser::make_INCR(yylloc); }
+"==" { return yy::parser::make_EQ(yylloc); }
+"!=" { return yy::parser::make_NE(yylloc); }
+"<=" { return yy::parser::make_LE(yylloc); }
+">=" { return yy::parser::make_GE(yylloc); }
 
   /* keywords */
-break { return yy::parser::make_BREAK(); }
-continue { return yy::parser::make_CONTINUE(); }
-switch { return yy::parser::make_SWITCH(); }
-case { return yy::parser::make_CASE(); }
-default { return yy::parser::make_DEFAULT(); }
-else { return yy::parser::make_ELSE(); }
-for { return yy::parser::make_FOR(); }
-do { return yy::parser::make_DO(); }
-if { return yy::parser::make_IF(); }
-int { return yy::parser::make_INT(); }
-return { return yy::parser::make_RETURN(); }
-while { return yy::parser::make_WHILE(); }
-goto { return yy::parser::make_GOTO(); }
+break { return yy::parser::make_BREAK(yylloc); }
+continue { return yy::parser::make_CONTINUE(yylloc); }
+switch { return yy::parser::make_SWITCH(yylloc); }
+case { return yy::parser::make_CASE(yylloc); }
+default { return yy::parser::make_DEFAULT(yylloc); }
+else { return yy::parser::make_ELSE(yylloc); }
+for { return yy::parser::make_FOR(yylloc); }
+do { return yy::parser::make_DO(yylloc); }
+if { return yy::parser::make_IF(yylloc); }
+int { return yy::parser::make_INT(yylloc); }
+return { return yy::parser::make_RETURN(yylloc); }
+while { return yy::parser::make_WHILE(yylloc); }
+goto { return yy::parser::make_GOTO(yylloc); }
 
   /* brackets */
-{bracket} { return yytext[0]; }
+"(" { return yy::parser::make_LEFT_PAREN(yylloc); }
+")" { return yy::parser::make_RIGHT_PAREN(yylloc); }
+"{" { return yy::parser::make_LEFT_CURLY(yylloc); }
+"}" { return yy::parser::make_RIGHT_CURLY(yylloc); }
+"[" { return yy::parser::make_LEFT_SQUARE(yylloc); }
+"]" { return yy::parser::make_RIGHT_SQUARE(yylloc); }
 
 {identifier} {
-    return yy::parser::make_ID(yytext);
+    return yy::parser::make_ID(yytext, yylloc);
   }
 
 {integer} {
-    return yy::parser::make_NUM(std::atoi(yytext));
+    return yy::parser::make_NUM(std::atoi(yytext), yylloc);
   }
 
   /* comments */
@@ -94,7 +115,7 @@ goto { return yy::parser::make_GOTO(); }
   }
 <C_COMMENT,CXX_COMMENT>.|\n { /* eat up */ }
 
-<<EOF>> { return yy::parser::make_EOF(); }
+<<EOF>> { return yy::parser::make_EOF(yylloc); }
 
 [ \t\r] {}
 

--- a/src/ast_dumper.cpp
+++ b/src/ast_dumper.cpp
@@ -66,8 +66,8 @@ std::string GetUnaryOperator(UnaryOperator op) {
 }  // namespace
 
 void AstDumper::Visit(const DeclNode& decl) {
-  std::cout << indenter_.Indent() << "DeclNode " << decl.id << ": "
-            << TypeToString(decl.type) << '\n';
+  std::cout << indenter_.Indent() << "DeclNode <" << decl.loc << "> " << decl.id
+            << ": " << TypeToString(decl.type) << '\n';
 
   if (decl.init) {
     indenter_.IncreaseLevel();
@@ -77,13 +77,13 @@ void AstDumper::Visit(const DeclNode& decl) {
 }
 
 void AstDumper::Visit(const ParamNode& parameter) {
-  std::cout << indenter_.Indent() << "ParamNode " << parameter.id << ": "
-            << TypeToString(parameter.type) << '\n';
+  std::cout << indenter_.Indent() << "ParamNode <" << parameter.loc << "> "
+            << parameter.id << ": " << TypeToString(parameter.type) << '\n';
 }
 
 void AstDumper::Visit(const FuncDefNode& func_def) {
-  std::cout << indenter_.Indent() << "FuncDefNode " << func_def.id << ": "
-            << TypeToString(func_def.type) << '\n';
+  std::cout << indenter_.Indent() << "FuncDefNode <" << func_def.loc << "> "
+            << func_def.id << ": " << TypeToString(func_def.type) << '\n';
 
   indenter_.IncreaseLevel();
   for (const auto& parameter : func_def.parameters) {
@@ -94,7 +94,7 @@ void AstDumper::Visit(const FuncDefNode& func_def) {
 }
 
 void AstDumper::Visit(const LoopInitNode& loop_init) {
-  std::cout << indenter_.Indent() << "LoopInitNode\n";
+  std::cout << indenter_.Indent() << "LoopInitNode <" << loop_init.loc << ">\n";
   indenter_.IncreaseLevel();
   std::visit([this](auto&& clause) { clause->Accept(*this); },
              loop_init.clause);
@@ -102,7 +102,8 @@ void AstDumper::Visit(const LoopInitNode& loop_init) {
 }
 
 void AstDumper::Visit(const CompoundStmtNode& compound_stmt) {
-  std::cout << indenter_.Indent() << "CompoundStmtNode\n";
+  std::cout << indenter_.Indent() << "CompoundStmtNode <" << compound_stmt.loc
+            << ">\n";
   indenter_.IncreaseLevel();
   for (const auto& item : compound_stmt.items) {
     std::visit([this](auto&& item) { item->Accept(*this); }, item);
@@ -111,7 +112,7 @@ void AstDumper::Visit(const CompoundStmtNode& compound_stmt) {
 }
 
 void AstDumper::Visit(const ProgramNode& program) {
-  std::cout << indenter_.Indent() << "ProgramNode\n";
+  std::cout << indenter_.Indent() << "ProgramNode <" << program.loc << ">\n";
   indenter_.IncreaseLevel();
   for (const auto& func_def : program.func_def_list) {
     func_def->Accept(*this);
@@ -120,7 +121,7 @@ void AstDumper::Visit(const ProgramNode& program) {
 }
 
 void AstDumper::Visit(const IfStmtNode& if_stmt) {
-  std::cout << indenter_.Indent() << "IfStmtNode\n";
+  std::cout << indenter_.Indent() << "IfStmtNode <" << if_stmt.loc << ">\n";
   indenter_.IncreaseLevel();
   if_stmt.predicate->Accept(*this);
   std::cout << indenter_.Indent() << "// Then\n";
@@ -135,7 +136,8 @@ void AstDumper::Visit(const IfStmtNode& if_stmt) {
 }
 
 void AstDumper::Visit(const WhileStmtNode& while_stmt) {
-  std::cout << indenter_.Indent() << "WhileStmtNode\n";
+  std::cout << indenter_.Indent() << "WhileStmtNode <" << while_stmt.loc
+            << ">\n";
   if (while_stmt.is_do_while) {
     indenter_.IncreaseLevel();
     std::cout << indenter_.Indent() << "// Do\n";
@@ -153,7 +155,7 @@ void AstDumper::Visit(const WhileStmtNode& while_stmt) {
 }
 
 void AstDumper::Visit(const ForStmtNode& for_stmt) {
-  std::cout << indenter_.Indent() << "ForStmtNode\n";
+  std::cout << indenter_.Indent() << "ForStmtNode <" << for_stmt.loc << ">\n";
   indenter_.IncreaseLevel();
   for_stmt.loop_init->Accept(*this);
   for_stmt.predicate->Accept(*this);
@@ -163,26 +165,31 @@ void AstDumper::Visit(const ForStmtNode& for_stmt) {
 }
 
 void AstDumper::Visit(const ReturnStmtNode& ret_stmt) {
-  std::cout << indenter_.Indent() << "ReturnStmtNode\n";
+  std::cout << indenter_.Indent() << "ReturnStmtNode <" << ret_stmt.loc
+            << ">\n";
   indenter_.IncreaseLevel();
   ret_stmt.expr->Accept(*this);
   indenter_.DecreaseLevel();
 }
 
 void AstDumper::Visit(const GotoStmtNode& goto_stmt) {
-  std::cout << indenter_.Indent() << "GotoStmtNode " << goto_stmt.label << '\n';
+  std::cout << indenter_.Indent() << "GotoStmtNode <" << goto_stmt.loc << "> "
+            << goto_stmt.label << '\n';
 }
 
 void AstDumper::Visit(const BreakStmtNode& break_stmt) {
-  std::cout << indenter_.Indent() << "BreakStmtNode\n";
+  std::cout << indenter_.Indent() << "BreakStmtNode <" << break_stmt.loc
+            << ">\n";
 }
 
 void AstDumper::Visit(const ContinueStmtNode& continue_stmt) {
-  std::cout << indenter_.Indent() << "ContinueStmtNode\n";
+  std::cout << indenter_.Indent() << "ContinueStmtNode <" << continue_stmt.loc
+            << ">\n";
 }
 
 void AstDumper::Visit(const SwitchStmtNode& switch_stmt) {
-  std::cout << indenter_.Indent() << "SwitchStmtNode\n";
+  std::cout << indenter_.Indent() << "SwitchStmtNode <" << switch_stmt.loc
+            << ">\n";
   indenter_.IncreaseLevel();
   switch_stmt.ctrl->Accept(*this);
   switch_stmt.stmt->Accept(*this);
@@ -190,15 +197,15 @@ void AstDumper::Visit(const SwitchStmtNode& switch_stmt) {
 }
 
 void AstDumper::Visit(const IdLabeledStmtNode& id_labeled_stmt) {
-  std::cout << indenter_.Indent() << "IdLabeledStmtNode "
-            << id_labeled_stmt.label << '\n';
+  std::cout << indenter_.Indent() << "IdLabeledStmtNode <"
+            << id_labeled_stmt.loc << "> " << id_labeled_stmt.label << '\n';
   indenter_.IncreaseLevel();
   id_labeled_stmt.stmt->Accept(*this);
   indenter_.DecreaseLevel();
 }
 
 void AstDumper::Visit(const CaseStmtNode& case_stmt) {
-  std::cout << indenter_.Indent() << "CaseStmtNode\n";
+  std::cout << indenter_.Indent() << "CaseStmtNode <" << case_stmt.loc << ">\n";
   indenter_.IncreaseLevel();
   case_stmt.expr->Accept(*this);
   case_stmt.stmt->Accept(*this);
@@ -206,35 +213,37 @@ void AstDumper::Visit(const CaseStmtNode& case_stmt) {
 }
 
 void AstDumper::Visit(const DefaultStmtNode& default_stmt) {
-  std::cout << indenter_.Indent() << "DefaultStmtNode\n";
+  std::cout << indenter_.Indent() << "DefaultStmtNode <" << default_stmt.loc
+            << ">\n";
   indenter_.IncreaseLevel();
   default_stmt.stmt->Accept(*this);
   indenter_.DecreaseLevel();
 }
 
 void AstDumper::Visit(const ExprStmtNode& expr_stmt) {
-  std::cout << indenter_.Indent() << "ExprStmtNode\n";
+  std::cout << indenter_.Indent() << "ExprStmtNode <" << expr_stmt.loc << ">\n";
   indenter_.IncreaseLevel();
   expr_stmt.expr->Accept(*this);
   indenter_.DecreaseLevel();
 }
 
 void AstDumper::Visit(const NullExprNode& null_expr) {
-  std::cout << indenter_.Indent() << "NullStmtNode\n";
+  std::cout << indenter_.Indent() << "NullStmtNode <" << null_expr.loc << ">\n";
 }
 
 void AstDumper::Visit(const IdExprNode& id_expr) {
-  std::cout << indenter_.Indent() << "IdExprNode " << id_expr.id << ": "
-            << TypeToString(id_expr.type) << '\n';
+  std::cout << indenter_.Indent() << "IdExprNode <" << id_expr.loc << "> "
+            << id_expr.id << ": " << TypeToString(id_expr.type) << '\n';
 }
 
 void AstDumper::Visit(const IntConstExprNode& int_expr) {
-  std::cout << indenter_.Indent() << "IntConstExprNode " << int_expr.val << ": "
-            << TypeToString(int_expr.type) << '\n';
+  std::cout << indenter_.Indent() << "IntConstExprNode <" << int_expr.loc
+            << "> " << int_expr.val << ": " << TypeToString(int_expr.type)
+            << '\n';
 }
 
 void AstDumper::Visit(const ArgExprNode& arg_expr) {
-  std::cout << indenter_.Indent() << "ArgExprNode "
+  std::cout << indenter_.Indent() << "ArgExprNode <" << arg_expr.loc << "> "
             << TypeToString(arg_expr.type) << '\n';
   indenter_.IncreaseLevel();
   arg_expr.arg->Accept(*this);
@@ -242,8 +251,8 @@ void AstDumper::Visit(const ArgExprNode& arg_expr) {
 }
 
 void AstDumper::Visit(const FuncCallExprNode& call_expr) {
-  std::cout << indenter_.Indent() << "FuncCallExprNode "
-            << TypeToString(call_expr.type) << '\n';
+  std::cout << indenter_.Indent() << "FuncCallExprNode <" << call_expr.loc
+            << "> " << TypeToString(call_expr.type) << '\n';
   indenter_.IncreaseLevel();
   call_expr.func_expr->Accept(*this);
   for (const auto& arg : call_expr.args) {
@@ -253,7 +262,7 @@ void AstDumper::Visit(const FuncCallExprNode& call_expr) {
 }
 
 void AstDumper::Visit(const UnaryExprNode& unary_expr) {
-  std::cout << indenter_.Indent() << "UnaryExprNode "
+  std::cout << indenter_.Indent() << "UnaryExprNode <" << unary_expr.loc << "> "
             << TypeToString(unary_expr.type) << " "
             << GetUnaryOperator(unary_expr.op) << '\n';
   indenter_.IncreaseLevel();
@@ -262,7 +271,7 @@ void AstDumper::Visit(const UnaryExprNode& unary_expr) {
 }
 
 void AstDumper::Visit(const BinaryExprNode& bin_expr) {
-  std::cout << indenter_.Indent() << "BinaryExprNode "
+  std::cout << indenter_.Indent() << "BinaryExprNode <" << bin_expr.loc << "> "
             << TypeToString(bin_expr.type) << " "
             << GetBinaryOperator(bin_expr.op) << '\n';
   indenter_.IncreaseLevel();
@@ -272,8 +281,9 @@ void AstDumper::Visit(const BinaryExprNode& bin_expr) {
 }
 
 void AstDumper::Visit(const SimpleAssignmentExprNode& assign_expr) {
-  std::cout << indenter_.Indent() << "SimpleAssignmentExprNode "
-            << TypeToString(assign_expr.type) << '\n';
+  std::cout << indenter_.Indent() << "SimpleAssignmentExprNode <"
+            << assign_expr.loc << "> " << TypeToString(assign_expr.type)
+            << '\n';
   indenter_.IncreaseLevel();
   assign_expr.lhs->Accept(*this);
   assign_expr.rhs->Accept(*this);

--- a/test/typecheck/assignment_expr.exp
+++ b/test/typecheck/assignment_expr.exp
@@ -1,10 +1,10 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode a: int
-      ExprStmtNode
-        SimpleAssignmentExprNode int
-          IdExprNode a: int
-          BinaryExprNode int +
-            IntConstExprNode 3: int
-            IntConstExprNode 2: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> a: int
+      ExprStmtNode <3:3>
+        SimpleAssignmentExprNode <3:5> int
+          IdExprNode <3:3> a: int
+          BinaryExprNode <3:9> int +
+            IntConstExprNode <3:7> 3: int
+            IntConstExprNode <3:11> 2: int

--- a/test/typecheck/bin_expr.exp
+++ b/test/typecheck/bin_expr.exp
@@ -1,37 +1,37 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      ExprStmtNode
-        BinaryExprNode int +
-          IntConstExprNode 1: int
-          IntConstExprNode 2: int
-      ExprStmtNode
-        BinaryExprNode int -
-          IntConstExprNode 1: int
-          IntConstExprNode 2: int
-      ExprStmtNode
-        BinaryExprNode int *
-          IntConstExprNode 1: int
-          IntConstExprNode 2: int
-      ExprStmtNode
-        BinaryExprNode int /
-          IntConstExprNode 1: int
-          IntConstExprNode 2: int
-      ExprStmtNode
-        BinaryExprNode int %
-          IntConstExprNode 1: int
-          IntConstExprNode 2: int
-      ExprStmtNode
-        BinaryExprNode int +
-          BinaryExprNode int +
-            BinaryExprNode int -
-              IntConstExprNode 1: int
-              BinaryExprNode int *
-                IntConstExprNode 2: int
-                IntConstExprNode 3: int
-            BinaryExprNode int /
-              IntConstExprNode 4: int
-              IntConstExprNode 5: int
-          BinaryExprNode int %
-            IntConstExprNode 6: int
-            IntConstExprNode 2: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      ExprStmtNode <2:3>
+        BinaryExprNode <2:5> int +
+          IntConstExprNode <2:3> 1: int
+          IntConstExprNode <2:7> 2: int
+      ExprStmtNode <3:3>
+        BinaryExprNode <3:5> int -
+          IntConstExprNode <3:3> 1: int
+          IntConstExprNode <3:7> 2: int
+      ExprStmtNode <4:3>
+        BinaryExprNode <4:5> int *
+          IntConstExprNode <4:3> 1: int
+          IntConstExprNode <4:7> 2: int
+      ExprStmtNode <5:3>
+        BinaryExprNode <5:5> int /
+          IntConstExprNode <5:3> 1: int
+          IntConstExprNode <5:7> 2: int
+      ExprStmtNode <6:3>
+        BinaryExprNode <6:5> int %
+          IntConstExprNode <6:3> 1: int
+          IntConstExprNode <6:7> 2: int
+      ExprStmtNode <7:3>
+        BinaryExprNode <7:21> int +
+          BinaryExprNode <7:13> int +
+            BinaryExprNode <7:5> int -
+              IntConstExprNode <7:3> 1: int
+              BinaryExprNode <7:9> int *
+                IntConstExprNode <7:7> 2: int
+                IntConstExprNode <7:11> 3: int
+            BinaryExprNode <7:17> int /
+              IntConstExprNode <7:15> 4: int
+              IntConstExprNode <7:19> 5: int
+          BinaryExprNode <7:25> int %
+            IntConstExprNode <7:23> 6: int
+            IntConstExprNode <7:27> 2: int

--- a/test/typecheck/break_stmt.exp
+++ b/test/typecheck/break_stmt.exp
@@ -1,11 +1,11 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      ForStmtNode
-        LoopInitNode
-          NullStmtNode
-        NullStmtNode
-        NullStmtNode
-        BreakStmtNode
-      ReturnStmtNode
-        IntConstExprNode 0: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      ForStmtNode <2:3>
+        LoopInitNode <2:8>
+          NullStmtNode <2:8>
+        NullStmtNode <2:9>
+        NullStmtNode <2:10>
+        BreakStmtNode <3:5>
+      ReturnStmtNode <5:3>
+        IntConstExprNode <5:10> 0: int

--- a/test/typecheck/comment.exp
+++ b/test/typecheck/comment.exp
@@ -1,5 +1,5 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      ReturnStmtNode
-        IntConstExprNode 0: int
+ProgramNode <1:1>
+  FuncDefNode <4:5> main: int
+    CompoundStmtNode <4:40>
+      ReturnStmtNode <15:3>
+        IntConstExprNode <15:10> 0: int

--- a/test/typecheck/comp_expr.exp
+++ b/test/typecheck/comp_expr.exp
@@ -1,27 +1,27 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      ExprStmtNode
-        BinaryExprNode int >
-          IntConstExprNode 1: int
-          IntConstExprNode 2: int
-      ExprStmtNode
-        BinaryExprNode int <
-          IntConstExprNode 1: int
-          IntConstExprNode 2: int
-      ExprStmtNode
-        BinaryExprNode int >=
-          IntConstExprNode 1: int
-          IntConstExprNode 2: int
-      ExprStmtNode
-        BinaryExprNode int <=
-          IntConstExprNode 1: int
-          IntConstExprNode 2: int
-      ExprStmtNode
-        BinaryExprNode int ==
-          IntConstExprNode 1: int
-          IntConstExprNode 2: int
-      ExprStmtNode
-        BinaryExprNode int !=
-          IntConstExprNode 1: int
-          IntConstExprNode 2: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      ExprStmtNode <2:3>
+        BinaryExprNode <2:5> int >
+          IntConstExprNode <2:3> 1: int
+          IntConstExprNode <2:7> 2: int
+      ExprStmtNode <3:3>
+        BinaryExprNode <3:5> int <
+          IntConstExprNode <3:3> 1: int
+          IntConstExprNode <3:7> 2: int
+      ExprStmtNode <4:3>
+        BinaryExprNode <4:5> int >=
+          IntConstExprNode <4:3> 1: int
+          IntConstExprNode <4:8> 2: int
+      ExprStmtNode <5:3>
+        BinaryExprNode <5:5> int <=
+          IntConstExprNode <5:3> 1: int
+          IntConstExprNode <5:8> 2: int
+      ExprStmtNode <6:3>
+        BinaryExprNode <6:5> int ==
+          IntConstExprNode <6:3> 1: int
+          IntConstExprNode <6:8> 2: int
+      ExprStmtNode <7:3>
+        BinaryExprNode <7:5> int !=
+          IntConstExprNode <7:3> 1: int
+          IntConstExprNode <7:8> 2: int

--- a/test/typecheck/compound_stmt.exp
+++ b/test/typecheck/compound_stmt.exp
@@ -1,17 +1,17 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode i: int
-        IntConstExprNode 1: int
-      ExprStmtNode
-        SimpleAssignmentExprNode int
-          IdExprNode i: int
-          BinaryExprNode int +
-            IdExprNode i: int
-            IntConstExprNode 1: int
-      DeclNode j: int
-        IntConstExprNode 2: int
-      ReturnStmtNode
-        BinaryExprNode int +
-          IdExprNode i: int
-          IdExprNode j: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> i: int
+        IntConstExprNode <2:11> 1: int
+      ExprStmtNode <3:3>
+        SimpleAssignmentExprNode <3:5> int
+          IdExprNode <3:3> i: int
+          BinaryExprNode <3:9> int +
+            IdExprNode <3:7> i: int
+            IntConstExprNode <3:11> 1: int
+      DeclNode <4:7> j: int
+        IntConstExprNode <4:11> 2: int
+      ReturnStmtNode <5:3>
+        BinaryExprNode <5:12> int +
+          IdExprNode <5:10> i: int
+          IdExprNode <5:14> j: int

--- a/test/typecheck/continue_stmt.exp
+++ b/test/typecheck/continue_stmt.exp
@@ -1,27 +1,27 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode a: int
-        IntConstExprNode 0: int
-      WhileStmtNode
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> a: int
+        IntConstExprNode <2:11> 0: int
+      WhileStmtNode <3:3>
         // Do
-        CompoundStmtNode
-          IfStmtNode
-            IntConstExprNode 1: int
+        CompoundStmtNode <3:6>
+          IfStmtNode <4:5>
+            IntConstExprNode <4:9> 1: int
             // Then
-            CompoundStmtNode
-              ExprStmtNode
-                SimpleAssignmentExprNode int
-                  IdExprNode a: int
-                  IntConstExprNode 5: int
-              ContinueStmtNode
-          ExprStmtNode
-            SimpleAssignmentExprNode int
-              IdExprNode a: int
-              IntConstExprNode 0: int
+            CompoundStmtNode <4:12>
+              ExprStmtNode <5:7>
+                SimpleAssignmentExprNode <5:9> int
+                  IdExprNode <5:7> a: int
+                  IntConstExprNode <5:11> 5: int
+              ContinueStmtNode <6:7>
+          ExprStmtNode <8:5>
+            SimpleAssignmentExprNode <8:7> int
+              IdExprNode <8:5> a: int
+              IntConstExprNode <8:9> 0: int
         // While
-        BinaryExprNode int <
-          IdExprNode a: int
-          IntConstExprNode 5: int
-      ReturnStmtNode
-        IntConstExprNode 0: int
+        BinaryExprNode <10:14> int <
+          IdExprNode <10:12> a: int
+          IntConstExprNode <10:16> 5: int
+      ReturnStmtNode <12:3>
+        IntConstExprNode <12:10> 0: int

--- a/test/typecheck/decl.exp
+++ b/test/typecheck/decl.exp
@@ -1,6 +1,6 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode i: int
-        IntConstExprNode 0: int
-      DeclNode j: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> i: int
+        IntConstExprNode <2:11> 0: int
+      DeclNode <3:7> j: int

--- a/test/typecheck/do_while_single_stmt.exp
+++ b/test/typecheck/do_while_single_stmt.exp
@@ -1,19 +1,19 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode i: int
-        IntConstExprNode 5: int
-      WhileStmtNode
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> i: int
+        IntConstExprNode <2:11> 5: int
+      WhileStmtNode <3:3>
         // Do
-        ExprStmtNode
-          SimpleAssignmentExprNode int
-            IdExprNode i: int
-            BinaryExprNode int -
-              IdExprNode i: int
-              IntConstExprNode 1: int
+        ExprStmtNode <4:5>
+          SimpleAssignmentExprNode <4:7> int
+            IdExprNode <4:5> i: int
+            BinaryExprNode <4:11> int -
+              IdExprNode <4:9> i: int
+              IntConstExprNode <4:13> 1: int
         // While
-        BinaryExprNode int >
-          IdExprNode i: int
-          IntConstExprNode 0: int
-      ReturnStmtNode
-        IdExprNode i: int
+        BinaryExprNode <5:12> int >
+          IdExprNode <5:10> i: int
+          IntConstExprNode <5:14> 0: int
+      ReturnStmtNode <7:3>
+        IdExprNode <7:10> i: int

--- a/test/typecheck/do_while_stmt.exp
+++ b/test/typecheck/do_while_stmt.exp
@@ -1,20 +1,20 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode i: int
-        IntConstExprNode 0: int
-      WhileStmtNode
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> i: int
+        IntConstExprNode <2:11> 0: int
+      WhileStmtNode <3:3>
         // Do
-        CompoundStmtNode
-          ExprStmtNode
-            SimpleAssignmentExprNode int
-              IdExprNode i: int
-              BinaryExprNode int +
-                IdExprNode i: int
-                IntConstExprNode 1: int
+        CompoundStmtNode <3:6>
+          ExprStmtNode <4:5>
+            SimpleAssignmentExprNode <4:7> int
+              IdExprNode <4:5> i: int
+              BinaryExprNode <4:11> int +
+                IdExprNode <4:9> i: int
+                IntConstExprNode <4:13> 1: int
         // While
-        BinaryExprNode int <
-          IdExprNode i: int
-          IntConstExprNode 5: int
-      ReturnStmtNode
-        IntConstExprNode 0: int
+        BinaryExprNode <5:14> int <
+          IdExprNode <5:12> i: int
+          IntConstExprNode <5:16> 5: int
+      ReturnStmtNode <7:3>
+        IntConstExprNode <7:10> 0: int

--- a/test/typecheck/for_infinite_loop.exp
+++ b/test/typecheck/for_infinite_loop.exp
@@ -1,12 +1,12 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      ForStmtNode
-        LoopInitNode
-          NullStmtNode
-        NullStmtNode
-        NullStmtNode
-        ExprStmtNode
-          NullStmtNode
-      ReturnStmtNode
-        IntConstExprNode 0: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      ForStmtNode <2:3>
+        LoopInitNode <2:8>
+          NullStmtNode <2:8>
+        NullStmtNode <2:9>
+        NullStmtNode <2:10>
+        ExprStmtNode <2:11>
+          NullStmtNode <2:11>
+      ReturnStmtNode <5:3>
+        IntConstExprNode <5:10> 0: int

--- a/test/typecheck/for_nested_stmt.exp
+++ b/test/typecheck/for_nested_stmt.exp
@@ -1,39 +1,39 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode k: int
-        IntConstExprNode 0: int
-      ForStmtNode
-        LoopInitNode
-          DeclNode i: int
-            IntConstExprNode 0: int
-        BinaryExprNode int <
-          IdExprNode i: int
-          IntConstExprNode 5: int
-        SimpleAssignmentExprNode int
-          IdExprNode i: int
-          BinaryExprNode int +
-            IdExprNode i: int
-            IntConstExprNode 1: int
-        CompoundStmtNode
-          ForStmtNode
-            LoopInitNode
-              DeclNode j: int
-                IntConstExprNode 0: int
-            BinaryExprNode int <
-              IdExprNode j: int
-              IntConstExprNode 5: int
-            SimpleAssignmentExprNode int
-              IdExprNode j: int
-              BinaryExprNode int +
-                IdExprNode j: int
-                IntConstExprNode 1: int
-            CompoundStmtNode
-              ExprStmtNode
-                SimpleAssignmentExprNode int
-                  IdExprNode k: int
-                  BinaryExprNode int +
-                    IdExprNode k: int
-                    IntConstExprNode 1: int
-      ReturnStmtNode
-        IntConstExprNode 0: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> k: int
+        IntConstExprNode <2:11> 0: int
+      ForStmtNode <3:3>
+        LoopInitNode <3:8>
+          DeclNode <3:12> i: int
+            IntConstExprNode <3:16> 0: int
+        BinaryExprNode <3:21> int <
+          IdExprNode <3:19> i: int
+          IntConstExprNode <3:23> 5: int
+        SimpleAssignmentExprNode <3:28> int
+          IdExprNode <3:26> i: int
+          BinaryExprNode <3:32> int +
+            IdExprNode <3:30> i: int
+            IntConstExprNode <3:34> 1: int
+        CompoundStmtNode <3:37>
+          ForStmtNode <4:5>
+            LoopInitNode <4:10>
+              DeclNode <4:14> j: int
+                IntConstExprNode <4:18> 0: int
+            BinaryExprNode <4:23> int <
+              IdExprNode <4:21> j: int
+              IntConstExprNode <4:25> 5: int
+            SimpleAssignmentExprNode <4:30> int
+              IdExprNode <4:28> j: int
+              BinaryExprNode <4:34> int +
+                IdExprNode <4:32> j: int
+                IntConstExprNode <4:36> 1: int
+            CompoundStmtNode <4:39>
+              ExprStmtNode <5:7>
+                SimpleAssignmentExprNode <5:9> int
+                  IdExprNode <5:7> k: int
+                  BinaryExprNode <5:13> int +
+                    IdExprNode <5:11> k: int
+                    IntConstExprNode <5:15> 1: int
+      ReturnStmtNode <9:3>
+        IntConstExprNode <9:10> 0: int

--- a/test/typecheck/for_stmt.exp
+++ b/test/typecheck/for_stmt.exp
@@ -1,28 +1,28 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode j: int
-        IntConstExprNode 0: int
-      DeclNode i: int
-      ForStmtNode
-        LoopInitNode
-          SimpleAssignmentExprNode int
-            IdExprNode i: int
-            IntConstExprNode 0: int
-        BinaryExprNode int <
-          IdExprNode i: int
-          IntConstExprNode 5: int
-        SimpleAssignmentExprNode int
-          IdExprNode i: int
-          BinaryExprNode int +
-            IdExprNode i: int
-            IntConstExprNode 1: int
-        CompoundStmtNode
-          ExprStmtNode
-            SimpleAssignmentExprNode int
-              IdExprNode j: int
-              BinaryExprNode int +
-                IdExprNode j: int
-                IntConstExprNode 1: int
-      ReturnStmtNode
-        IntConstExprNode 0: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> j: int
+        IntConstExprNode <2:11> 0: int
+      DeclNode <3:7> i: int
+      ForStmtNode <4:3>
+        LoopInitNode <4:8>
+          SimpleAssignmentExprNode <4:10> int
+            IdExprNode <4:8> i: int
+            IntConstExprNode <4:12> 0: int
+        BinaryExprNode <4:17> int <
+          IdExprNode <4:15> i: int
+          IntConstExprNode <4:19> 5: int
+        SimpleAssignmentExprNode <4:24> int
+          IdExprNode <4:22> i: int
+          BinaryExprNode <4:28> int +
+            IdExprNode <4:26> i: int
+            IntConstExprNode <4:30> 1: int
+        CompoundStmtNode <4:33>
+          ExprStmtNode <5:5>
+            SimpleAssignmentExprNode <5:7> int
+              IdExprNode <5:5> j: int
+              BinaryExprNode <5:11> int +
+                IdExprNode <5:9> j: int
+                IntConstExprNode <5:13> 1: int
+      ReturnStmtNode <8:3>
+        IntConstExprNode <8:10> 0: int

--- a/test/typecheck/func_call.exp
+++ b/test/typecheck/func_call.exp
@@ -1,10 +1,10 @@
-ProgramNode
-  FuncDefNode five: int
-    CompoundStmtNode
-      ReturnStmtNode
-        IntConstExprNode 5: int
-  FuncDefNode main: int
-    CompoundStmtNode
-      ReturnStmtNode
-        FuncCallExprNode int
-          IdExprNode five: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> five: int
+    CompoundStmtNode <1:12>
+      ReturnStmtNode <2:3>
+        IntConstExprNode <2:10> 5: int
+  FuncDefNode <5:5> main: int
+    CompoundStmtNode <5:12>
+      ReturnStmtNode <6:3>
+        FuncCallExprNode <6:10> int
+          IdExprNode <6:10> five: int

--- a/test/typecheck/func_call_param.exp
+++ b/test/typecheck/func_call_param.exp
@@ -1,39 +1,39 @@
-ProgramNode
-  FuncDefNode sum: int
-    ParamNode a: int
-    ParamNode b: int
-    ParamNode c: int
-    CompoundStmtNode
-      ReturnStmtNode
-        BinaryExprNode int +
-          BinaryExprNode int +
-            IdExprNode a: int
-            IdExprNode b: int
-          IdExprNode c: int
-  FuncDefNode add_five: int
-    ParamNode d: int
-    CompoundStmtNode
-      ReturnStmtNode
-        BinaryExprNode int +
-          IdExprNode d: int
-          IntConstExprNode 5: int
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode a: int
-        FuncCallExprNode int
-          IdExprNode sum: int
-          ArgExprNode int
-            IntConstExprNode 1: int
-          ArgExprNode int
-            IntConstExprNode 2: int
-          ArgExprNode int
-            IntConstExprNode 3: int
-      DeclNode b: int
-        BinaryExprNode int +
-          IdExprNode a: int
-          IntConstExprNode 4: int
-      ReturnStmtNode
-        FuncCallExprNode int
-          IdExprNode add_five: int
-          ArgExprNode int
-            IdExprNode b: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> sum: int
+    ParamNode <1:13> a: int
+    ParamNode <1:20> b: int
+    ParamNode <1:27> c: int
+    CompoundStmtNode <1:30>
+      ReturnStmtNode <2:3>
+        BinaryExprNode <2:16> int +
+          BinaryExprNode <2:12> int +
+            IdExprNode <2:10> a: int
+            IdExprNode <2:14> b: int
+          IdExprNode <2:18> c: int
+  FuncDefNode <5:5> add_five: int
+    ParamNode <5:18> d: int
+    CompoundStmtNode <5:21>
+      ReturnStmtNode <6:3>
+        BinaryExprNode <6:12> int +
+          IdExprNode <6:10> d: int
+          IntConstExprNode <6:14> 5: int
+  FuncDefNode <9:5> main: int
+    CompoundStmtNode <9:12>
+      DeclNode <10:7> a: int
+        FuncCallExprNode <10:11> int
+          IdExprNode <10:11> sum: int
+          ArgExprNode <10:15> int
+            IntConstExprNode <10:15> 1: int
+          ArgExprNode <10:18> int
+            IntConstExprNode <10:18> 2: int
+          ArgExprNode <10:21> int
+            IntConstExprNode <10:21> 3: int
+      DeclNode <11:7> b: int
+        BinaryExprNode <11:13> int +
+          IdExprNode <11:11> a: int
+          IntConstExprNode <11:15> 4: int
+      ReturnStmtNode <12:3>
+        FuncCallExprNode <12:10> int
+          IdExprNode <12:10> add_five: int
+          ArgExprNode <12:19> int
+            IdExprNode <12:19> b: int

--- a/test/typecheck/goto_stmt.exp
+++ b/test/typecheck/goto_stmt.exp
@@ -1,15 +1,15 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode i: int
-        IntConstExprNode 0: int
-      IdLabeledStmtNode begin
-        ExprStmtNode
-          SimpleAssignmentExprNode int
-            IdExprNode i: int
-            BinaryExprNode int +
-              IdExprNode i: int
-              IntConstExprNode 1: int
-      GotoStmtNode begin
-      ReturnStmtNode
-        IntConstExprNode 0: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> i: int
+        IntConstExprNode <2:11> 0: int
+      IdLabeledStmtNode <3:1> begin
+        ExprStmtNode <4:3>
+          SimpleAssignmentExprNode <4:5> int
+            IdExprNode <4:3> i: int
+            BinaryExprNode <4:9> int +
+              IdExprNode <4:7> i: int
+              IntConstExprNode <4:11> 1: int
+      GotoStmtNode <5:3> begin
+      ReturnStmtNode <6:3>
+        IntConstExprNode <6:10> 0: int

--- a/test/typecheck/id_expr.exp
+++ b/test/typecheck/id_expr.exp
@@ -1,6 +1,6 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode i: int
-      DeclNode j: int
-        IdExprNode i: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> i: int
+      DeclNode <3:7> j: int
+        IdExprNode <3:11> i: int

--- a/test/typecheck/identifier.exp
+++ b/test/typecheck/identifier.exp
@@ -1,12 +1,12 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode _: int
-      DeclNode __: int
-      DeclNode i: int
-      DeclNode _1: int
-      DeclNode _i: int
-      DeclNode _i1: int
-      DeclNode _i1_: int
-      DeclNode _I: int
-      DeclNode _I1: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> _: int
+      DeclNode <3:7> __: int
+      DeclNode <4:7> i: int
+      DeclNode <5:7> _1: int
+      DeclNode <6:7> _i: int
+      DeclNode <7:7> _i1: int
+      DeclNode <8:7> _i1_: int
+      DeclNode <9:7> _I: int
+      DeclNode <10:7> _I1: int

--- a/test/typecheck/if_else_nested_single_stmt.exp
+++ b/test/typecheck/if_else_nested_single_stmt.exp
@@ -1,31 +1,31 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode i: int
-        IntConstExprNode 5: int
-      IfStmtNode
-        BinaryExprNode int <
-          IdExprNode i: int
-          IntConstExprNode 10: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> i: int
+        IntConstExprNode <2:11> 5: int
+      IfStmtNode <3:3>
+        BinaryExprNode <3:9> int <
+          IdExprNode <3:7> i: int
+          IntConstExprNode <3:11> 10: int
         // Then
-        IfStmtNode
-          BinaryExprNode int <
-            IdExprNode i: int
-            IntConstExprNode 5: int
+        IfStmtNode <4:5>
+          BinaryExprNode <4:11> int <
+            IdExprNode <4:9> i: int
+            IntConstExprNode <4:13> 5: int
           // Then
-          ExprStmtNode
-            SimpleAssignmentExprNode int
-              IdExprNode i: int
-              IntConstExprNode 2: int
+          ExprStmtNode <5:7>
+            SimpleAssignmentExprNode <5:9> int
+              IdExprNode <5:7> i: int
+              IntConstExprNode <5:11> 2: int
           // Else
-          ExprStmtNode
-            SimpleAssignmentExprNode int
-              IdExprNode i: int
-              IntConstExprNode 7: int
+          ExprStmtNode <7:7>
+            SimpleAssignmentExprNode <7:9> int
+              IdExprNode <7:7> i: int
+              IntConstExprNode <7:11> 7: int
         // Else
-        ExprStmtNode
-          SimpleAssignmentExprNode int
-            IdExprNode i: int
-            IntConstExprNode 15: int
-      ReturnStmtNode
-        IdExprNode i: int
+        ExprStmtNode <9:5>
+          SimpleAssignmentExprNode <9:7> int
+            IdExprNode <9:5> i: int
+            IntConstExprNode <9:9> 15: int
+      ReturnStmtNode <11:3>
+        IdExprNode <11:10> i: int

--- a/test/typecheck/if_else_nested_stmt.exp
+++ b/test/typecheck/if_else_nested_stmt.exp
@@ -1,47 +1,47 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode i: int
-        IntConstExprNode 25: int
-      IfStmtNode
-        BinaryExprNode int <
-          IdExprNode i: int
-          IntConstExprNode 10: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> i: int
+        IntConstExprNode <2:11> 25: int
+      IfStmtNode <3:3>
+        BinaryExprNode <3:9> int <
+          IdExprNode <3:7> i: int
+          IntConstExprNode <3:11> 10: int
         // Then
-        CompoundStmtNode
-          IfStmtNode
-            BinaryExprNode int <
-              IdExprNode i: int
-              IntConstExprNode 5: int
+        CompoundStmtNode <3:15>
+          IfStmtNode <4:5>
+            BinaryExprNode <4:11> int <
+              IdExprNode <4:9> i: int
+              IntConstExprNode <4:13> 5: int
             // Then
-            CompoundStmtNode
-              ExprStmtNode
-                SimpleAssignmentExprNode int
-                  IdExprNode i: int
-                  IntConstExprNode 2: int
+            CompoundStmtNode <4:16>
+              ExprStmtNode <5:7>
+                SimpleAssignmentExprNode <5:9> int
+                  IdExprNode <5:7> i: int
+                  IntConstExprNode <5:11> 2: int
             // Else
-            CompoundStmtNode
-              ExprStmtNode
-                SimpleAssignmentExprNode int
-                  IdExprNode i: int
-                  IntConstExprNode 7: int
+            CompoundStmtNode <6:12>
+              ExprStmtNode <7:7>
+                SimpleAssignmentExprNode <7:9> int
+                  IdExprNode <7:7> i: int
+                  IntConstExprNode <7:11> 7: int
         // Else
-        CompoundStmtNode
-          IfStmtNode
-            BinaryExprNode int >
-              IdExprNode i: int
-              IntConstExprNode 20: int
+        CompoundStmtNode <9:10>
+          IfStmtNode <10:5>
+            BinaryExprNode <10:11> int >
+              IdExprNode <10:9> i: int
+              IntConstExprNode <10:13> 20: int
             // Then
-            CompoundStmtNode
-              ExprStmtNode
-                SimpleAssignmentExprNode int
-                  IdExprNode i: int
-                  IntConstExprNode 30: int
+            CompoundStmtNode <10:17>
+              ExprStmtNode <11:7>
+                SimpleAssignmentExprNode <11:9> int
+                  IdExprNode <11:7> i: int
+                  IntConstExprNode <11:11> 30: int
             // Else
-            CompoundStmtNode
-              ExprStmtNode
-                SimpleAssignmentExprNode int
-                  IdExprNode i: int
-                  IntConstExprNode 15: int
-      ReturnStmtNode
-        IdExprNode i: int
+            CompoundStmtNode <12:12>
+              ExprStmtNode <13:7>
+                SimpleAssignmentExprNode <13:9> int
+                  IdExprNode <13:7> i: int
+                  IntConstExprNode <13:11> 15: int
+      ReturnStmtNode <17:3>
+        IdExprNode <17:10> i: int

--- a/test/typecheck/if_else_single_stmt.exp
+++ b/test/typecheck/if_else_single_stmt.exp
@@ -1,25 +1,25 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode i: int
-        IntConstExprNode 2: int
-      IfStmtNode
-        BinaryExprNode int >
-          IdExprNode i: int
-          IntConstExprNode 0: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> i: int
+        IntConstExprNode <2:11> 2: int
+      IfStmtNode <3:3>
+        BinaryExprNode <3:9> int >
+          IdExprNode <3:7> i: int
+          IntConstExprNode <3:11> 0: int
         // Then
-        ExprStmtNode
-          SimpleAssignmentExprNode int
-            IdExprNode i: int
-            BinaryExprNode int -
-              IdExprNode i: int
-              IntConstExprNode 1: int
+        ExprStmtNode <4:5>
+          SimpleAssignmentExprNode <4:7> int
+            IdExprNode <4:5> i: int
+            BinaryExprNode <4:11> int -
+              IdExprNode <4:9> i: int
+              IntConstExprNode <4:13> 1: int
         // Else
-        ExprStmtNode
-          SimpleAssignmentExprNode int
-            IdExprNode i: int
-            BinaryExprNode int +
-              IdExprNode i: int
-              IntConstExprNode 1: int
-      ReturnStmtNode
-        IdExprNode i: int
+        ExprStmtNode <6:5>
+          SimpleAssignmentExprNode <6:7> int
+            IdExprNode <6:5> i: int
+            BinaryExprNode <6:11> int +
+              IdExprNode <6:9> i: int
+              IntConstExprNode <6:13> 1: int
+      ReturnStmtNode <8:3>
+        IdExprNode <8:10> i: int

--- a/test/typecheck/if_else_stmt.exp
+++ b/test/typecheck/if_else_stmt.exp
@@ -1,25 +1,25 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode i: int
-        IntConstExprNode 2: int
-      IfStmtNode
-        BinaryExprNode int <
-          IdExprNode i: int
-          IntConstExprNode 0: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> i: int
+        IntConstExprNode <2:11> 2: int
+      IfStmtNode <3:3>
+        BinaryExprNode <3:9> int <
+          IdExprNode <3:7> i: int
+          IntConstExprNode <3:11> 0: int
         // Then
-        CompoundStmtNode
-          ExprStmtNode
-            SimpleAssignmentExprNode int
-              IdExprNode i: int
-              IntConstExprNode 0: int
+        CompoundStmtNode <3:14>
+          ExprStmtNode <4:5>
+            SimpleAssignmentExprNode <4:7> int
+              IdExprNode <4:5> i: int
+              IntConstExprNode <4:9> 0: int
         // Else
-        CompoundStmtNode
-          ExprStmtNode
-            SimpleAssignmentExprNode int
-              IdExprNode i: int
-              BinaryExprNode int +
-                IdExprNode i: int
-                IntConstExprNode 1: int
-      ReturnStmtNode
-        IdExprNode i: int
+        CompoundStmtNode <5:10>
+          ExprStmtNode <6:5>
+            SimpleAssignmentExprNode <6:7> int
+              IdExprNode <6:5> i: int
+              BinaryExprNode <6:11> int +
+                IdExprNode <6:9> i: int
+                IntConstExprNode <6:13> 1: int
+      ReturnStmtNode <9:3>
+        IdExprNode <9:10> i: int

--- a/test/typecheck/if_single_stmt.exp
+++ b/test/typecheck/if_single_stmt.exp
@@ -1,18 +1,18 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode i: int
-        IntConstExprNode 2: int
-      IfStmtNode
-        BinaryExprNode int >
-          IdExprNode i: int
-          IntConstExprNode 0: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> i: int
+        IntConstExprNode <2:11> 2: int
+      IfStmtNode <3:3>
+        BinaryExprNode <3:9> int >
+          IdExprNode <3:7> i: int
+          IntConstExprNode <3:11> 0: int
         // Then
-        ExprStmtNode
-          SimpleAssignmentExprNode int
-            IdExprNode i: int
-            BinaryExprNode int +
-              IdExprNode i: int
-              IntConstExprNode 1: int
-      ReturnStmtNode
-        IntConstExprNode 0: int
+        ExprStmtNode <4:5>
+          SimpleAssignmentExprNode <4:7> int
+            IdExprNode <4:5> i: int
+            BinaryExprNode <4:11> int +
+              IdExprNode <4:9> i: int
+              IntConstExprNode <4:13> 1: int
+      ReturnStmtNode <6:3>
+        IntConstExprNode <6:10> 0: int

--- a/test/typecheck/if_stmt.exp
+++ b/test/typecheck/if_stmt.exp
@@ -1,15 +1,15 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode i: int
-        IntConstExprNode 2: int
-      IfStmtNode
-        BinaryExprNode int >
-          IdExprNode i: int
-          IntConstExprNode 0: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> i: int
+        IntConstExprNode <2:11> 2: int
+      IfStmtNode <3:3>
+        BinaryExprNode <3:9> int >
+          IdExprNode <3:7> i: int
+          IntConstExprNode <3:11> 0: int
         // Then
-        CompoundStmtNode
-          ReturnStmtNode
-            IdExprNode i: int
-      ReturnStmtNode
-        IntConstExprNode 0: int
+        CompoundStmtNode <3:14>
+          ReturnStmtNode <4:5>
+            IdExprNode <4:12> i: int
+      ReturnStmtNode <7:3>
+        IntConstExprNode <7:10> 0: int

--- a/test/typecheck/int_const_expr.exp
+++ b/test/typecheck/int_const_expr.exp
@@ -1,5 +1,5 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      ExprStmtNode
-        IntConstExprNode 1: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      ExprStmtNode <2:3>
+        IntConstExprNode <2:3> 1: int

--- a/test/typecheck/null_stmt.exp
+++ b/test/typecheck/null_stmt.exp
@@ -1,5 +1,5 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      ExprStmtNode
-        NullStmtNode
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      ExprStmtNode <1:13>
+        NullStmtNode <1:13>

--- a/test/typecheck/paren_expr.exp
+++ b/test/typecheck/paren_expr.exp
@@ -1,19 +1,19 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      ExprStmtNode
-        BinaryExprNode int *
-          IntConstExprNode 4: int
-          BinaryExprNode int -
-            IntConstExprNode 5: int
-            IntConstExprNode 2: int
-      ExprStmtNode
-        BinaryExprNode int /
-          IntConstExprNode 10: int
-          BinaryExprNode int *
-            BinaryExprNode int +
-              IntConstExprNode 5: int
-              IntConstExprNode 1: int
-            IntConstExprNode 3: int
-      ReturnStmtNode
-        IntConstExprNode 0: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      ExprStmtNode <2:3>
+        BinaryExprNode <2:5> int *
+          IntConstExprNode <2:3> 4: int
+          BinaryExprNode <2:10> int -
+            IntConstExprNode <2:8> 5: int
+            IntConstExprNode <2:12> 2: int
+      ExprStmtNode <3:3>
+        BinaryExprNode <3:6> int /
+          IntConstExprNode <3:3> 10: int
+          BinaryExprNode <3:17> int *
+            BinaryExprNode <3:12> int +
+              IntConstExprNode <3:10> 5: int
+              IntConstExprNode <3:14> 1: int
+            IntConstExprNode <3:19> 3: int
+      ReturnStmtNode <5:3>
+        IntConstExprNode <5:10> 0: int

--- a/test/typecheck/pointer.exp
+++ b/test/typecheck/pointer.exp
@@ -1,21 +1,21 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode a: int
-        IntConstExprNode 10: int
-      DeclNode b: int*
-      DeclNode c: int*
-        UnaryExprNode int* &
-          IdExprNode a: int
-      ExprStmtNode
-        SimpleAssignmentExprNode int*
-          IdExprNode b: int*
-          IdExprNode c: int*
-      ExprStmtNode
-        SimpleAssignmentExprNode int
-          UnaryExprNode int *
-            IdExprNode c: int*
-          IntConstExprNode 5: int
-      ReturnStmtNode
-        UnaryExprNode int *
-          IdExprNode c: int*
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> a: int
+        IntConstExprNode <2:11> 10: int
+      DeclNode <3:8> b: int*
+      DeclNode <4:8> c: int*
+        UnaryExprNode <4:12> int* &
+          IdExprNode <4:13> a: int
+      ExprStmtNode <5:3>
+        SimpleAssignmentExprNode <5:5> int*
+          IdExprNode <5:3> b: int*
+          IdExprNode <5:7> c: int*
+      ExprStmtNode <6:3>
+        SimpleAssignmentExprNode <6:6> int
+          UnaryExprNode <6:3> int *
+            IdExprNode <6:4> c: int*
+          IntConstExprNode <6:8> 5: int
+      ReturnStmtNode <8:3>
+        UnaryExprNode <8:10> int *
+          IdExprNode <8:11> c: int*

--- a/test/typecheck/pointer_param.exp
+++ b/test/typecheck/pointer_param.exp
@@ -1,28 +1,28 @@
-ProgramNode
-  FuncDefNode add: int
-    ParamNode x: int*
-    ParamNode y: int*
-    CompoundStmtNode
-      ReturnStmtNode
-        BinaryExprNode int +
-          UnaryExprNode int *
-            IdExprNode x: int*
-          UnaryExprNode int *
-            IdExprNode y: int*
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode a: int
-        IntConstExprNode 3: int
-      DeclNode b: int
-        IntConstExprNode 5: int
-      DeclNode c: int*
-        UnaryExprNode int* &
-          IdExprNode b: int
-      ReturnStmtNode
-        FuncCallExprNode int
-          IdExprNode add: int
-          ArgExprNode int*
-            UnaryExprNode int* &
-              IdExprNode a: int
-          ArgExprNode int*
-            IdExprNode c: int*
+ProgramNode <1:1>
+  FuncDefNode <1:5> add: int
+    ParamNode <1:14> x: int*
+    ParamNode <1:22> y: int*
+    CompoundStmtNode <1:25>
+      ReturnStmtNode <2:3>
+        BinaryExprNode <2:13> int +
+          UnaryExprNode <2:10> int *
+            IdExprNode <2:11> x: int*
+          UnaryExprNode <2:15> int *
+            IdExprNode <2:16> y: int*
+  FuncDefNode <5:5> main: int
+    CompoundStmtNode <5:12>
+      DeclNode <6:7> a: int
+        IntConstExprNode <6:11> 3: int
+      DeclNode <7:7> b: int
+        IntConstExprNode <7:11> 5: int
+      DeclNode <8:8> c: int*
+        UnaryExprNode <8:12> int* &
+          IdExprNode <8:13> b: int
+      ReturnStmtNode <9:3>
+        FuncCallExprNode <9:10> int
+          IdExprNode <9:10> add: int
+          ArgExprNode <9:14> int*
+            UnaryExprNode <9:14> int* &
+              IdExprNode <9:15> a: int
+          ArgExprNode <9:18> int*
+            IdExprNode <9:18> c: int*

--- a/test/typecheck/return_stmt.exp
+++ b/test/typecheck/return_stmt.exp
@@ -1,5 +1,5 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      ReturnStmtNode
-        IntConstExprNode 0: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      ReturnStmtNode <2:3>
+        IntConstExprNode <2:10> 0: int

--- a/test/typecheck/switch_stmt.exp
+++ b/test/typecheck/switch_stmt.exp
@@ -1,29 +1,29 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode a: int
-        IntConstExprNode 1: int
-      SwitchStmtNode
-        IdExprNode a: int
-        CompoundStmtNode
-          CaseStmtNode
-            IntConstExprNode 1: int
-            ExprStmtNode
-              SimpleAssignmentExprNode int
-                IdExprNode a: int
-                IntConstExprNode 2: int
-          BreakStmtNode
-          CaseStmtNode
-            IntConstExprNode 2: int
-            ExprStmtNode
-              SimpleAssignmentExprNode int
-                IdExprNode a: int
-                IntConstExprNode 3: int
-          BreakStmtNode
-          DefaultStmtNode
-            ExprStmtNode
-              SimpleAssignmentExprNode int
-                IdExprNode a: int
-                IntConstExprNode 4: int
-      ReturnStmtNode
-        IdExprNode a: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> a: int
+        IntConstExprNode <2:11> 1: int
+      SwitchStmtNode <3:3>
+        IdExprNode <3:11> a: int
+        CompoundStmtNode <3:14>
+          CaseStmtNode <4:5>
+            IntConstExprNode <4:10> 1: int
+            ExprStmtNode <5:7>
+              SimpleAssignmentExprNode <5:9> int
+                IdExprNode <5:7> a: int
+                IntConstExprNode <5:11> 2: int
+          BreakStmtNode <6:7>
+          CaseStmtNode <7:5>
+            IntConstExprNode <7:10> 2: int
+            ExprStmtNode <8:7>
+              SimpleAssignmentExprNode <8:9> int
+                IdExprNode <8:7> a: int
+                IntConstExprNode <8:11> 3: int
+          BreakStmtNode <9:7>
+          DefaultStmtNode <10:5>
+            ExprStmtNode <11:7>
+              SimpleAssignmentExprNode <11:9> int
+                IdExprNode <11:7> a: int
+                IntConstExprNode <11:11> 4: int
+      ReturnStmtNode <13:3>
+        IdExprNode <13:10> a: int

--- a/test/typecheck/unary_expr.exp
+++ b/test/typecheck/unary_expr.exp
@@ -1,33 +1,33 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode i: int
-        IntConstExprNode 1: int
-      ExprStmtNode
-        UnaryExprNode int --
-          IdExprNode i: int
-      ExprStmtNode
-        UnaryExprNode int ++
-          IdExprNode i: int
-      ExprStmtNode
-        SimpleAssignmentExprNode int
-          IdExprNode i: int
-          UnaryExprNode int +
-            IdExprNode i: int
-      ExprStmtNode
-        SimpleAssignmentExprNode int
-          IdExprNode i: int
-          UnaryExprNode int -
-            IdExprNode i: int
-      ExprStmtNode
-        SimpleAssignmentExprNode int
-          IdExprNode i: int
-          UnaryExprNode int !
-            IdExprNode i: int
-      ExprStmtNode
-        SimpleAssignmentExprNode int
-          IdExprNode i: int
-          UnaryExprNode int ~
-            IdExprNode i: int
-      ReturnStmtNode
-        IntConstExprNode 0: int
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> i: int
+        IntConstExprNode <2:11> 1: int
+      ExprStmtNode <3:3>
+        UnaryExprNode <3:3> int --
+          IdExprNode <3:5> i: int
+      ExprStmtNode <4:3>
+        UnaryExprNode <4:3> int ++
+          IdExprNode <4:5> i: int
+      ExprStmtNode <5:3>
+        SimpleAssignmentExprNode <5:5> int
+          IdExprNode <5:3> i: int
+          UnaryExprNode <5:7> int +
+            IdExprNode <5:8> i: int
+      ExprStmtNode <6:3>
+        SimpleAssignmentExprNode <6:5> int
+          IdExprNode <6:3> i: int
+          UnaryExprNode <6:7> int -
+            IdExprNode <6:8> i: int
+      ExprStmtNode <7:3>
+        SimpleAssignmentExprNode <7:5> int
+          IdExprNode <7:3> i: int
+          UnaryExprNode <7:7> int !
+            IdExprNode <7:8> i: int
+      ExprStmtNode <8:3>
+        SimpleAssignmentExprNode <8:5> int
+          IdExprNode <8:3> i: int
+          UnaryExprNode <8:7> int ~
+            IdExprNode <8:8> i: int
+      ReturnStmtNode <10:3>
+        IntConstExprNode <10:10> 0: int

--- a/test/typecheck/while_single_stmt.exp
+++ b/test/typecheck/while_single_stmt.exp
@@ -1,19 +1,19 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode i: int
-        IntConstExprNode 5: int
-      WhileStmtNode
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> i: int
+        IntConstExprNode <2:11> 5: int
+      WhileStmtNode <3:3>
         // While
-        BinaryExprNode int >
-          IdExprNode i: int
-          IntConstExprNode 0: int
+        BinaryExprNode <3:12> int >
+          IdExprNode <3:10> i: int
+          IntConstExprNode <3:14> 0: int
         // Body
-        ExprStmtNode
-          SimpleAssignmentExprNode int
-            IdExprNode i: int
-            BinaryExprNode int -
-              IdExprNode i: int
-              IntConstExprNode 1: int
-      ReturnStmtNode
-        IdExprNode i: int
+        ExprStmtNode <4:5>
+          SimpleAssignmentExprNode <4:7> int
+            IdExprNode <4:5> i: int
+            BinaryExprNode <4:11> int -
+              IdExprNode <4:9> i: int
+              IntConstExprNode <4:13> 1: int
+      ReturnStmtNode <6:3>
+        IdExprNode <6:10> i: int

--- a/test/typecheck/while_stmt.exp
+++ b/test/typecheck/while_stmt.exp
@@ -1,20 +1,20 @@
-ProgramNode
-  FuncDefNode main: int
-    CompoundStmtNode
-      DeclNode i: int
-        IntConstExprNode 5: int
-      WhileStmtNode
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int
+    CompoundStmtNode <1:12>
+      DeclNode <2:7> i: int
+        IntConstExprNode <2:11> 5: int
+      WhileStmtNode <3:3>
         // While
-        BinaryExprNode int >
-          IdExprNode i: int
-          IntConstExprNode 0: int
+        BinaryExprNode <3:12> int >
+          IdExprNode <3:10> i: int
+          IntConstExprNode <3:14> 0: int
         // Body
-        CompoundStmtNode
-          ExprStmtNode
-            SimpleAssignmentExprNode int
-              IdExprNode i: int
-              BinaryExprNode int -
-                IdExprNode i: int
-                IntConstExprNode 1: int
-      ReturnStmtNode
-        IntConstExprNode 0: int
+        CompoundStmtNode <3:17>
+          ExprStmtNode <4:5>
+            SimpleAssignmentExprNode <4:7> int
+              IdExprNode <4:5> i: int
+              BinaryExprNode <4:11> int -
+                IdExprNode <4:9> i: int
+                IntConstExprNode <4:13> 1: int
+      ReturnStmtNode <7:3>
+        IntConstExprNode <7:10> 0: int


### PR DESCRIPTION
Due to the necessity of passing location with the token, they are now wrapped as a `symbol_type`. Consequently, the convenience of directly passing the token itself as the symbol is disabled, resulting in a more verbose syntax.

With this update, AST nodes now contain a location structure. The location of binary operations corresponds to the location of the operators, while the location of declarations/definitions corresponds to the location of the identifiers.

When dumping the AST nodes, the location is displayed immediately after the name of the node. It is enclosed within a pair of angle brackets and separates the line number from the column number using a colon: `AstNode <line:column>`. This formatting is similar to how LLVM handles its AST dump, with the distinction that LLVM shows ranges of the node, as it records more location information.

```
`-FunctionDecl 0xbdd400 <test/typecheck/decl.c:1:1, line:4:1> line:1:5 main 'int ()'
  `-CompoundStmt 0xbdd638 <col:12, line:4:1>
    |-DeclStmt 0xbdd588 <line:2:3, col:12>
    | `-VarDecl 0xbdd500 <col:3, col:11> col:7 i 'int' cinit
    |   `-IntegerLiteral 0xbdd568 <col:11> 'int' 0
    `-DeclStmt 0xbdd620 <line:3:3, col:8>
      `-VarDecl 0xbdd5b8 <col:3, col:7> col:7 j 'int'
```

If you have any suggestions regarding the naming of the Bison symbols, please let me know. Also, note that I did not check whether each output location in the test cases is correct or not, as I believe we can fix that up at any time if we find a mistake in the future.

Related to #128.