### PR TITLE
Generate executables directly

### DIFF
--- a/test/codegen/turnt.toml
+++ b/test/codegen/turnt.toml
@@ -1,7 +1,2 @@
-command = """\
-  ../../vitaminc -o {filename}.ssa {filename} \
-  && qbe -o {filename}.s {filename}.ssa \
-  && cc {filename}.s -o {filename}.o \
-  && ./{filename}.o \
-"""
+command = """../../vitaminc -o {filename}.o {filename} && ./{filename}.o"""
 output.exp = "-"


### PR DESCRIPTION
- Output option will be used to name executable instead of IR file. I recommend using the legendary `a.out` as default. 😎 
- Add `target` option to specify the target IR. We only support `qbe` for now, we will support `llvm` in the future.