### PR TITLE
Fix clang tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ tidy: y.tab.hpp
 	$(CLANG_TIDY) $(CLANG_TIDY_FLAGS) -p . $(SRC) $(INC) -- $(CXXFLAGS)
 
 clean:
-	rm -rf *.s *.o lex.yy.* y.tab.* *.output *.ssa $(TARGET) $(OBJS) $(DEPS)
+	rm -rf *.s *.o lex.yy.* y.tab.* *.output *.ssa *.out $(TARGET) $(OBJS) $(DEPS)
 	cd test/ && $(MAKE) clean
 
 -include $(DEPS)

--- a/main.cpp
+++ b/main.cpp
@@ -1,3 +1,5 @@
+#include <fmt/core.h>
+
 #include <cstdio>
 #include <cstdlib>
 #include <cxxopts.hpp>


### PR DESCRIPTION
- Fix clang tidy errors
- Clean `*.out` executables