### PR TITLE
Parse function pointers & combine types in a symbol entry

### DIFF
--- a/include/symbol.hpp
+++ b/include/symbol.hpp
@@ -5,17 +5,15 @@
 #include <memory>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "type.hpp"
 
 struct SymbolEntry {
   std::string id;
-  std::unique_ptr<Type> expr_type;
-  std::vector<std::unique_ptr<Type>> param_types{};
+  std::unique_ptr<Type> type;
 
   SymbolEntry(std::string id, std::unique_ptr<Type> expr_type)
-      : id{std::move(id)}, expr_type{std::move(expr_type)} {}
+      : id{std::move(id)}, type{std::move(expr_type)} {}
 };
 
 class SymbolTable {

--- a/src/qbe_ir_generator.cpp
+++ b/src/qbe_ir_generator.cpp
@@ -17,6 +17,7 @@
 #include "ast.hpp"
 #include "operator.hpp"
 #include "qbe/sigil.hpp"
+#include "type.hpp"
 
 // Since compiler-generated sigils are used more frequently, we include them
 // directly.

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -50,6 +50,20 @@ std::size_t PtrType::size() const {
 }
 
 std::string PtrType::ToString() const {
+  // For function pointer types, the '*' is placed between the return type and
+  // the parameter list.
+  if (const auto* base_func = dynamic_cast<const FuncType*>(base_type_.get())) {
+    auto str = base_func->return_type().ToString() + " (*)(";
+    for (auto i = std::size_t{0}, e = base_func->param_types().size(); i < e;
+         ++i) {
+      str += base_func->param_types().at(i)->ToString();
+      if (i < e - 1) {
+        str += ", ";
+      }
+    }
+    str += ")";
+    return str;
+  }
   return base_type_->ToString() + "*";
 }
 

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -3,6 +3,8 @@
 #include <cstddef>
 #include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 bool Type::IsEqual(PrimitiveType that) const noexcept {
   return IsEqual(PrimType{that});

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -110,8 +110,15 @@ std::size_t FuncType::size() const {
 }
 
 std::string FuncType::ToString() const {
-  // FIXME: This is to not break the tests; should include the parameter types.
-  return return_type_->ToString();
+  auto str = return_type_->ToString() + " (";
+  for (auto i = std::size_t{0}, e = param_types_.size(); i < e; ++i) {
+    str += param_types_.at(i)->ToString();
+    if (i < e - 1) {
+      str += ", ";
+    }
+  }
+  str += ")";
+  return str;
 }
 
 std::unique_ptr<Type> FuncType::Clone() const {

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -67,7 +67,7 @@ void TypeChecker::Visit(DeclArrNode& arr_decl) {
 
     for (auto& init : arr_decl.init_list) {
       init->Accept(*this);
-      if (!init->type->IsEqual(*symbol->expr_type)) {
+      if (!init->type->IsEqual(*symbol->type)) {
         // TODO: element unmatches array element type
       }
     }
@@ -113,7 +113,6 @@ void TypeChecker::Visit(FuncDefNode& func_def) {
       std::make_unique<SymbolEntry>(func_def.id, func_def.type->Clone());
   for (auto& parameter : func_def.parameters) {
     parameter->Accept(*this);
-    symbol->param_types.push_back(parameter->type->Clone());
   }
   env_.Add(std::move(symbol), ScopeKind::kFile);
 
@@ -153,8 +152,6 @@ void TypeChecker::InstallBuiltins_(ScopeStack& env) {
       "__builtin_print", std::make_unique<FuncType>(
                              std::make_unique<PrimType>(PrimitiveType::kInt),
                              std::move(param_types)));
-  symbol->param_types.emplace_back(
-      std::make_unique<PrimType>(PrimitiveType::kInt));
   env.Add(std::move(symbol), ScopeKind::kFile);
 }
 
@@ -298,9 +295,10 @@ void TypeChecker::Visit(NullExprNode&) {
 
 void TypeChecker::Visit(IdExprNode& id_expr) {
   if (auto symbol = env_.LookUp(id_expr.id)) {
-    id_expr.type = symbol->expr_type->Clone();
+    id_expr.type = symbol->type->Clone();
   } else {
     // TODO: 'id' undeclared
+    assert(false);
   }
 }
 

--- a/test/typecheck/array.exp
+++ b/test/typecheck/array.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclArrNode <2:7> a: int[3]
       ExprStmtNode <4:3>

--- a/test/typecheck/assignment_expr.exp
+++ b/test/typecheck/assignment_expr.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> a: int
       ExprStmtNode <3:3>

--- a/test/typecheck/bin_expr.exp
+++ b/test/typecheck/bin_expr.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       ExprStmtNode <2:3>
         BinaryExprNode <2:5> int +

--- a/test/typecheck/break_stmt.exp
+++ b/test/typecheck/break_stmt.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       ForStmtNode <2:3>
         LoopInitNode <2:8>

--- a/test/typecheck/comment.exp
+++ b/test/typecheck/comment.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <4:5> main: int
+  FuncDefNode <4:5> main: int ()
     CompoundStmtNode <4:40>
       ReturnStmtNode <15:3>
         IntConstExprNode <15:10> 0: int

--- a/test/typecheck/comp_expr.exp
+++ b/test/typecheck/comp_expr.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       ExprStmtNode <2:3>
         BinaryExprNode <2:5> int >

--- a/test/typecheck/compound_stmt.exp
+++ b/test/typecheck/compound_stmt.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> i: int
         IntConstExprNode <2:11> 1: int

--- a/test/typecheck/continue_stmt.exp
+++ b/test/typecheck/continue_stmt.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> a: int
         IntConstExprNode <2:11> 0: int

--- a/test/typecheck/decl.exp
+++ b/test/typecheck/decl.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> i: int
         IntConstExprNode <2:11> 0: int

--- a/test/typecheck/do_while_single_stmt.exp
+++ b/test/typecheck/do_while_single_stmt.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> i: int
         IntConstExprNode <2:11> 5: int

--- a/test/typecheck/do_while_stmt.exp
+++ b/test/typecheck/do_while_stmt.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> i: int
         IntConstExprNode <2:11> 0: int

--- a/test/typecheck/for_infinite_loop.exp
+++ b/test/typecheck/for_infinite_loop.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       ForStmtNode <2:3>
         LoopInitNode <2:8>

--- a/test/typecheck/for_nested_stmt.exp
+++ b/test/typecheck/for_nested_stmt.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> k: int
         IntConstExprNode <2:11> 0: int

--- a/test/typecheck/for_stmt.exp
+++ b/test/typecheck/for_stmt.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> j: int
         IntConstExprNode <2:11> 0: int

--- a/test/typecheck/func_call.exp
+++ b/test/typecheck/func_call.exp
@@ -1,10 +1,10 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> five: int
+  FuncDefNode <1:5> five: int ()
     CompoundStmtNode <1:12>
       ReturnStmtNode <2:3>
         IntConstExprNode <2:10> 5: int
-  FuncDefNode <5:5> main: int
+  FuncDefNode <5:5> main: int ()
     CompoundStmtNode <5:12>
       ReturnStmtNode <6:3>
-        FuncCallExprNode <6:10> int
-          IdExprNode <6:10> five: int
+        FuncCallExprNode <6:10> int ()
+          IdExprNode <6:10> five: int ()

--- a/test/typecheck/func_call.exp
+++ b/test/typecheck/func_call.exp
@@ -6,5 +6,5 @@ ProgramNode <1:1>
   FuncDefNode <5:5> main: int ()
     CompoundStmtNode <5:12>
       ReturnStmtNode <6:3>
-        FuncCallExprNode <6:10> int ()
+        FuncCallExprNode <6:10> int
           IdExprNode <6:10> five: int ()

--- a/test/typecheck/func_call_param.exp
+++ b/test/typecheck/func_call_param.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> sum: int
+  FuncDefNode <1:5> sum: int (int, int, int)
     ParamNode <1:13> a: int
     ParamNode <1:20> b: int
     ParamNode <1:27> c: int
@@ -10,18 +10,18 @@ ProgramNode <1:1>
             IdExprNode <2:10> a: int
             IdExprNode <2:14> b: int
           IdExprNode <2:18> c: int
-  FuncDefNode <5:5> add_five: int
+  FuncDefNode <5:5> add_five: int (int)
     ParamNode <5:18> d: int
     CompoundStmtNode <5:21>
       ReturnStmtNode <6:3>
         BinaryExprNode <6:12> int +
           IdExprNode <6:10> d: int
           IntConstExprNode <6:14> 5: int
-  FuncDefNode <9:5> main: int
+  FuncDefNode <9:5> main: int ()
     CompoundStmtNode <9:12>
       DeclVarNode <10:7> a: int
-        FuncCallExprNode <10:11> int
-          IdExprNode <10:11> sum: int
+        FuncCallExprNode <10:11> int (int, int, int)
+          IdExprNode <10:11> sum: int (int, int, int)
           ArgExprNode <10:15> int
             IntConstExprNode <10:15> 1: int
           ArgExprNode <10:18> int
@@ -33,7 +33,7 @@ ProgramNode <1:1>
           IdExprNode <11:11> a: int
           IntConstExprNode <11:15> 4: int
       ReturnStmtNode <12:3>
-        FuncCallExprNode <12:10> int
-          IdExprNode <12:10> add_five: int
+        FuncCallExprNode <12:10> int (int)
+          IdExprNode <12:10> add_five: int (int)
           ArgExprNode <12:19> int
             IdExprNode <12:19> b: int

--- a/test/typecheck/func_call_param.exp
+++ b/test/typecheck/func_call_param.exp
@@ -20,7 +20,7 @@ ProgramNode <1:1>
   FuncDefNode <9:5> main: int ()
     CompoundStmtNode <9:12>
       DeclVarNode <10:7> a: int
-        FuncCallExprNode <10:11> int (int, int, int)
+        FuncCallExprNode <10:11> int
           IdExprNode <10:11> sum: int (int, int, int)
           ArgExprNode <10:15> int
             IntConstExprNode <10:15> 1: int
@@ -33,7 +33,7 @@ ProgramNode <1:1>
           IdExprNode <11:11> a: int
           IntConstExprNode <11:15> 4: int
       ReturnStmtNode <12:3>
-        FuncCallExprNode <12:10> int (int)
+        FuncCallExprNode <12:10> int
           IdExprNode <12:10> add_five: int (int)
           ArgExprNode <12:19> int
             IdExprNode <12:19> b: int

--- a/test/typecheck/func_pointer.c
+++ b/test/typecheck/func_pointer.c
@@ -1,0 +1,8 @@
+int add(int a, int b) {
+  return a + b;
+}
+
+int main() {
+  int (*p)(int, int);
+  return 0;
+}

--- a/test/typecheck/func_pointer.exp
+++ b/test/typecheck/func_pointer.exp
@@ -1,0 +1,14 @@
+ProgramNode <1:1>
+  FuncDefNode <1:5> add: int (int, int)
+    ParamNode <1:13> a: int
+    ParamNode <1:20> b: int
+    CompoundStmtNode <1:23>
+      ReturnStmtNode <2:3>
+        BinaryExprNode <2:12> int +
+          IdExprNode <2:10> a: int
+          IdExprNode <2:14> b: int
+  FuncDefNode <5:5> main: int ()
+    CompoundStmtNode <5:12>
+      DeclVarNode <6:9> p: int (*)(int, int)
+      ReturnStmtNode <7:3>
+        IntConstExprNode <7:10> 0: int

--- a/test/typecheck/goto_stmt.exp
+++ b/test/typecheck/goto_stmt.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> i: int
         IntConstExprNode <2:11> 0: int

--- a/test/typecheck/id_expr.exp
+++ b/test/typecheck/id_expr.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> i: int
       DeclVarNode <3:7> j: int

--- a/test/typecheck/identifier.exp
+++ b/test/typecheck/identifier.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> _: int
       DeclVarNode <3:7> __: int

--- a/test/typecheck/if_else_nested_single_stmt.exp
+++ b/test/typecheck/if_else_nested_single_stmt.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> i: int
         IntConstExprNode <2:11> 5: int

--- a/test/typecheck/if_else_nested_stmt.exp
+++ b/test/typecheck/if_else_nested_stmt.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> i: int
         IntConstExprNode <2:11> 25: int

--- a/test/typecheck/if_else_single_stmt.exp
+++ b/test/typecheck/if_else_single_stmt.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> i: int
         IntConstExprNode <2:11> 2: int

--- a/test/typecheck/if_else_stmt.exp
+++ b/test/typecheck/if_else_stmt.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> i: int
         IntConstExprNode <2:11> 2: int

--- a/test/typecheck/if_single_stmt.exp
+++ b/test/typecheck/if_single_stmt.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> i: int
         IntConstExprNode <2:11> 2: int

--- a/test/typecheck/if_stmt.exp
+++ b/test/typecheck/if_stmt.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> i: int
         IntConstExprNode <2:11> 2: int

--- a/test/typecheck/int_const_expr.exp
+++ b/test/typecheck/int_const_expr.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       ExprStmtNode <2:3>
         IntConstExprNode <2:3> 1: int

--- a/test/typecheck/null_stmt.exp
+++ b/test/typecheck/null_stmt.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       ExprStmtNode <1:13>
         NullStmtNode <1:13>

--- a/test/typecheck/paren_expr.exp
+++ b/test/typecheck/paren_expr.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       ExprStmtNode <2:3>
         BinaryExprNode <2:5> int *

--- a/test/typecheck/pointer.exp
+++ b/test/typecheck/pointer.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> a: int
         IntConstExprNode <2:11> 10: int

--- a/test/typecheck/pointer_param.exp
+++ b/test/typecheck/pointer_param.exp
@@ -19,7 +19,7 @@ ProgramNode <1:1>
         UnaryExprNode <8:12> int* &
           IdExprNode <8:13> b: int
       ReturnStmtNode <9:3>
-        FuncCallExprNode <9:10> int (int*, int*)
+        FuncCallExprNode <9:10> int
           IdExprNode <9:10> add: int (int*, int*)
           ArgExprNode <9:14> int*
             UnaryExprNode <9:14> int* &

--- a/test/typecheck/pointer_param.exp
+++ b/test/typecheck/pointer_param.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> add: int
+  FuncDefNode <1:5> add: int (int*, int*)
     ParamNode <1:14> x: int*
     ParamNode <1:22> y: int*
     CompoundStmtNode <1:25>
@@ -9,7 +9,7 @@ ProgramNode <1:1>
             IdExprNode <2:11> x: int*
           UnaryExprNode <2:15> int *
             IdExprNode <2:16> y: int*
-  FuncDefNode <5:5> main: int
+  FuncDefNode <5:5> main: int ()
     CompoundStmtNode <5:12>
       DeclVarNode <6:7> a: int
         IntConstExprNode <6:11> 3: int
@@ -19,8 +19,8 @@ ProgramNode <1:1>
         UnaryExprNode <8:12> int* &
           IdExprNode <8:13> b: int
       ReturnStmtNode <9:3>
-        FuncCallExprNode <9:10> int
-          IdExprNode <9:10> add: int
+        FuncCallExprNode <9:10> int (int*, int*)
+          IdExprNode <9:10> add: int (int*, int*)
           ArgExprNode <9:14> int*
             UnaryExprNode <9:14> int* &
               IdExprNode <9:15> a: int

--- a/test/typecheck/pointer_to_pointer.exp
+++ b/test/typecheck/pointer_to_pointer.exp
@@ -11,7 +11,7 @@ ProgramNode <1:1>
           IdExprNode <4:16> pa: int*
       ExprStmtNode <5:3>
         FuncCallExprNode <5:3> int
-          IdExprNode <5:3> __builtin_print: int
+          IdExprNode <5:3> __builtin_print: int (int)
           ArgExprNode <5:19> int
             UnaryExprNode <5:19> int *
               UnaryExprNode <5:20> int* *
@@ -28,7 +28,7 @@ ProgramNode <1:1>
           IdExprNode <9:10> pb: int*
       ExprStmtNode <10:3>
         FuncCallExprNode <10:3> int
-          IdExprNode <10:3> __builtin_print: int
+          IdExprNode <10:3> __builtin_print: int (int)
           ArgExprNode <10:19> int
             UnaryExprNode <10:19> int *
               UnaryExprNode <10:20> int* *
@@ -41,7 +41,7 @@ ProgramNode <1:1>
           IntConstExprNode <12:11> 30: int
       ExprStmtNode <13:3>
         FuncCallExprNode <13:3> int
-          IdExprNode <13:3> __builtin_print: int
+          IdExprNode <13:3> __builtin_print: int (int)
           ArgExprNode <13:19> int
             IdExprNode <13:19> b: int
       ReturnStmtNode <15:3>

--- a/test/typecheck/pointer_to_pointer.exp
+++ b/test/typecheck/pointer_to_pointer.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> a: int
         IntConstExprNode <2:11> 10: int

--- a/test/typecheck/pointer_to_pointer_param.exp
+++ b/test/typecheck/pointer_to_pointer_param.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> add: int
+  FuncDefNode <1:5> add: int (int**, int**)
     ParamNode <1:15> x: int**
     ParamNode <1:24> y: int**
     CompoundStmtNode <1:27>
@@ -11,7 +11,7 @@ ProgramNode <1:1>
           UnaryExprNode <2:16> int *
             UnaryExprNode <2:17> int* *
               IdExprNode <2:18> y: int**
-  FuncDefNode <5:5> main: int
+  FuncDefNode <5:5> main: int ()
     CompoundStmtNode <5:12>
       DeclVarNode <6:7> a: int
         IntConstExprNode <6:11> 3: int
@@ -24,8 +24,8 @@ ProgramNode <1:1>
         UnaryExprNode <9:12> int* &
           IdExprNode <9:13> b: int
       ReturnStmtNode <10:3>
-        FuncCallExprNode <10:10> int
-          IdExprNode <10:10> add: int
+        FuncCallExprNode <10:10> int (int**, int**)
+          IdExprNode <10:10> add: int (int**, int**)
           ArgExprNode <10:14> int**
             UnaryExprNode <10:14> int** &
               IdExprNode <10:15> c: int*

--- a/test/typecheck/pointer_to_pointer_param.exp
+++ b/test/typecheck/pointer_to_pointer_param.exp
@@ -24,7 +24,7 @@ ProgramNode <1:1>
         UnaryExprNode <9:12> int* &
           IdExprNode <9:13> b: int
       ReturnStmtNode <10:3>
-        FuncCallExprNode <10:10> int (int**, int**)
+        FuncCallExprNode <10:10> int
           IdExprNode <10:10> add: int (int**, int**)
           ArgExprNode <10:14> int**
             UnaryExprNode <10:14> int** &

--- a/test/typecheck/postfix_arith_expr.exp
+++ b/test/typecheck/postfix_arith_expr.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> a: int
         IntConstExprNode <2:11> 0: int

--- a/test/typecheck/return_stmt.exp
+++ b/test/typecheck/return_stmt.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       ReturnStmtNode <2:3>
         IntConstExprNode <2:10> 0: int

--- a/test/typecheck/switch_stmt.exp
+++ b/test/typecheck/switch_stmt.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> a: int
         IntConstExprNode <2:11> 1: int

--- a/test/typecheck/unary_expr.exp
+++ b/test/typecheck/unary_expr.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> i: int
         IntConstExprNode <2:11> 1: int

--- a/test/typecheck/while_single_stmt.exp
+++ b/test/typecheck/while_single_stmt.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> i: int
         IntConstExprNode <2:11> 5: int

--- a/test/typecheck/while_stmt.exp
+++ b/test/typecheck/while_stmt.exp
@@ -1,5 +1,5 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int
+  FuncDefNode <1:5> main: int ()
     CompoundStmtNode <1:12>
       DeclVarNode <2:7> i: int
         IntConstExprNode <2:11> 5: int


### PR DESCRIPTION
During the implementation of function pointer support, I realized that several potentially impactful changes have been made. Therefore, I'd like to submit a pull request at this juncture.

- The `expr_type` and `param_types` in a symbol entry have been combined into a single `type`, as our type system can now accommodate function types as a unified type.
- Parameter types are now included in the dump of a function type, resolving a _FIXME_.
- The parser can now handle declarations of function pointer. Their parameters do not include identifiers, distinguishing them from function definitions.

> [!note]
> Since our type checker doesn't abort the check on error, I prefer inserting `assert` at the time I touch that piece of code. I've encountered several strange crashes caused by not aborting the program on error. Additionally, adding assertions allows us to quickly pinpoint where the error is occurring.