### PR TITLE
Parse struct and union

### DIFF
--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -111,6 +111,38 @@ struct ArrDeclNode : public DeclNode {
   std::vector<std::unique_ptr<ExprNode>> init_list;
 };
 
+struct DefStructNode : public DeclNode {
+  DefStructNode(Location loc, std::string id, std::unique_ptr<Type> type,
+                std::vector<std::unique_ptr<FieldNode>> field_list)
+      : DeclNode{loc, std::move(id), std::move(type)},
+        field_list{std::move(field_list)} {}
+
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
+
+  std::vector<std::unique_ptr<FieldNode>> field_list;
+};
+
+struct DefUnionNode : public DeclNode {
+  DefUnionNode(Location loc, std::string id, std::unique_ptr<Type> type,
+               std::vector<std::unique_ptr<FieldNode>> field_list)
+      : DeclNode{loc, std::move(id), std::move(type)},
+        field_list{std::move(field_list)} {}
+
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
+
+  std::vector<std::unique_ptr<FieldNode>> field_list;
+};
+
+/// @brief A field in a struct or an union.
+struct FieldNode : public DeclNode {
+  using DeclNode::DeclNode;
+
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
+};
+
 struct ParamNode : public DeclNode {
   using DeclNode::DeclNode;
 

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -111,17 +111,17 @@ struct ArrDeclNode : public DeclNode {
   std::vector<std::unique_ptr<ExprNode>> init_list;
 };
 
-/// @brief Record Declaration Node holds the definition of struct or union.
+/// @brief This holds the declaration of struct or union type.
 struct RecordDeclNode : public DeclNode {
   RecordDeclNode(Location loc, std::string id, std::unique_ptr<Type> type,
-                 std::vector<std::unique_ptr<FieldNode>> field_list)
+                 std::vector<std::unique_ptr<FieldNode>> fields)
       : DeclNode{loc, std::move(id), std::move(type)},
-        field_list{std::move(field_list)} {}
+        fields{std::move(fields)} {}
 
   void Accept(NonModifyingVisitor&) const override;
   void Accept(ModifyingVisitor&) override;
 
-  std::vector<std::unique_ptr<FieldNode>> field_list;
+  std::vector<std::unique_ptr<FieldNode>> fields;
 };
 
 /// @brief A field in a struct or an union.

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -111,21 +111,10 @@ struct ArrDeclNode : public DeclNode {
   std::vector<std::unique_ptr<ExprNode>> init_list;
 };
 
-struct DefStructNode : public DeclNode {
-  DefStructNode(Location loc, std::string id, std::unique_ptr<Type> type,
-                std::vector<std::unique_ptr<FieldNode>> field_list)
-      : DeclNode{loc, std::move(id), std::move(type)},
-        field_list{std::move(field_list)} {}
-
-  void Accept(NonModifyingVisitor&) const override;
-  void Accept(ModifyingVisitor&) override;
-
-  std::vector<std::unique_ptr<FieldNode>> field_list;
-};
-
-struct DefUnionNode : public DeclNode {
-  DefUnionNode(Location loc, std::string id, std::unique_ptr<Type> type,
-               std::vector<std::unique_ptr<FieldNode>> field_list)
+/// @brief Record Declaration Node holds the definition of struct or union.
+struct RecordDeclNode : public DeclNode {
+  RecordDeclNode(Location loc, std::string id, std::unique_ptr<Type> type,
+                 std::vector<std::unique_ptr<FieldNode>> field_list)
       : DeclNode{loc, std::move(id), std::move(type)},
         field_list{std::move(field_list)} {}
 

--- a/include/ast_dumper.hpp
+++ b/include/ast_dumper.hpp
@@ -10,6 +10,8 @@ class AstDumper : public NonModifyingVisitor {
   void Visit(const LoopInitNode&) override;
   void Visit(const VarDeclNode&) override;
   void Visit(const ArrDeclNode&) override;
+  void Visit(const RecordDeclNode&) override;
+  void Visit(const FieldNode&) override;
   void Visit(const ParamNode&) override;
   void Visit(const FuncDefNode&) override;
   void Visit(const CompoundStmtNode&) override;

--- a/include/qbe_ir_generator.hpp
+++ b/include/qbe_ir_generator.hpp
@@ -17,6 +17,8 @@ class QbeIrGenerator : public NonModifyingVisitor {
   void Visit(const LoopInitNode&) override;
   void Visit(const VarDeclNode&) override;
   void Visit(const ArrDeclNode&) override;
+  void Visit(const RecordDeclNode&) override;
+  void Visit(const FieldNode&) override;
   void Visit(const ParamNode&) override;
   void Visit(const FuncDefNode&) override;
   void Visit(const CompoundStmtNode&) override;

--- a/include/type.hpp
+++ b/include/type.hpp
@@ -194,12 +194,10 @@ class StructType : public Type {
 
 class UnionType : public Type {
  public:
-  /// @param selected_ The index of the selected field in the union.
-  explicit UnionType(std::vector<std::unique_ptr<Type>> field_types,
-                     std::size_t selected = 0)
-      : field_types_{std::move(field_types)}, selected_{selected} {}
+  explicit UnionType(std::vector<std::unique_ptr<Type>> field_types)
+      : field_types_{std::move(field_types)} {}
 
-  bool IsStruct() const noexcept override {
+  bool IsUnion() const noexcept override {
     return true;
   }
 
@@ -210,7 +208,6 @@ class UnionType : public Type {
 
  private:
   std::vector<std::unique_ptr<Type>> field_types_;
-  std::size_t selected_;
 };
 
 #endif  // TYPE_HPP_

--- a/include/type.hpp
+++ b/include/type.hpp
@@ -30,6 +30,12 @@ class Type {
   virtual bool IsFunc() const noexcept {
     return false;
   }
+  virtual bool IsStruct() const noexcept {
+    return false;
+  }
+  virtual bool IsUnion() const noexcept {
+    return false;
+  }
 
   virtual bool IsEqual(const Type& that) const noexcept = 0;
   /// @brief A convenience function to compare with a primitive type.
@@ -166,6 +172,45 @@ class FuncType : public Type {
   std::vector<std::unique_ptr<Type>> param_types_;
 
   bool ConvertibleHook_(const Type& that) const noexcept override;
+};
+
+class StructType : public Type {
+ public:
+  explicit StructType(std::vector<std::unique_ptr<Type>> field_types)
+      : field_types_{std::move(field_types)} {}
+
+  bool IsStruct() const noexcept override {
+    return true;
+  }
+
+  bool IsEqual(const Type& that) const noexcept override;
+  std::size_t size() const override;
+  std::string ToString() const override;
+  std::unique_ptr<Type> Clone() const override;
+
+ private:
+  std::vector<std::unique_ptr<Type>> field_types_;
+};
+
+class UnionType : public Type {
+ public:
+  /// @param selected_ The index of the selected field in the union.
+  explicit UnionType(std::vector<std::unique_ptr<Type>> field_types,
+                     std::size_t selected = 0)
+      : field_types_{std::move(field_types)}, selected_{selected} {}
+
+  bool IsStruct() const noexcept override {
+    return true;
+  }
+
+  bool IsEqual(const Type& that) const noexcept override;
+  std::size_t size() const override;
+  std::string ToString() const override;
+  std::unique_ptr<Type> Clone() const override;
+
+ private:
+  std::vector<std::unique_ptr<Type>> field_types_;
+  std::size_t selected_;
 };
 
 #endif  // TYPE_HPP_

--- a/include/type_checker.hpp
+++ b/include/type_checker.hpp
@@ -13,6 +13,8 @@ class TypeChecker : public ModifyingVisitor {
   void Visit(LoopInitNode&) override;
   void Visit(VarDeclNode&) override;
   void Visit(ArrDeclNode&) override;
+  void Visit(RecordDeclNode&) override;
+  void Visit(FieldNode&) override;
   void Visit(ParamNode&) override;
   void Visit(FuncDefNode&) override;
   void Visit(CompoundStmtNode&) override;

--- a/include/visitor.hpp
+++ b/include/visitor.hpp
@@ -12,6 +12,8 @@ struct ExprNode;
 struct DeclNode;
 struct VarDeclNode;
 struct ArrDeclNode;
+struct RecordDeclNode;
+struct FieldNode;
 struct ParamNode;
 struct FuncDefNode;
 struct LoopInitNode;
@@ -64,6 +66,8 @@ class Visitor {
   virtual void Visit(CondMut<DeclNode>&){};
   virtual void Visit(CondMut<VarDeclNode>&){};
   virtual void Visit(CondMut<ArrDeclNode>&){};
+  virtual void Visit(CondMut<RecordDeclNode>&){};
+  virtual void Visit(CondMut<FieldNode>&){};
   virtual void Visit(CondMut<ParamNode>&){};
   virtual void Visit(CondMut<FuncDefNode>&){};
   virtual void Visit(CondMut<LoopInitNode>&){};

--- a/lexer.l
+++ b/lexer.l
@@ -90,6 +90,8 @@ int { return yy::parser::make_INT(yylloc); }
 return { return yy::parser::make_RETURN(yylloc); }
 while { return yy::parser::make_WHILE(yylloc); }
 goto { return yy::parser::make_GOTO(yylloc); }
+struct { return yy::parser::make_STRUCT(yylloc); }
+union { return yy::parser::make_UNION(yylloc); }
 
   /* brackets */
 "(" { return yy::parser::make_LEFT_PAREN(yylloc); }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -58,19 +58,11 @@ void ArrDeclNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
-void DefStructNode::Accept(NonModifyingVisitor& v) const {
+void RecordDeclNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void DefStructNode::Accept(ModifyingVisitor& v) {
-  v.Visit(*this);
-}
-
-void DefUnionNode::Accept(NonModifyingVisitor& v) const {
-  v.Visit(*this);
-}
-
-void DefUnionNode::Accept(ModifyingVisitor& v) {
+void RecordDeclNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -58,6 +58,30 @@ void ArrDeclNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
+void DefStructNode::Accept(NonModifyingVisitor& v) const {
+  v.Visit(*this);
+}
+
+void DefStructNode::Accept(ModifyingVisitor& v) {
+  v.Visit(*this);
+}
+
+void DefUnionNode::Accept(NonModifyingVisitor& v) const {
+  v.Visit(*this);
+}
+
+void DefUnionNode::Accept(ModifyingVisitor& v) {
+  v.Visit(*this);
+}
+
+void FieldNode::Accept(NonModifyingVisitor& v) const {
+  v.Visit(*this);
+}
+
+void FieldNode::Accept(ModifyingVisitor& v) {
+  v.Visit(*this);
+}
+
 void ParamNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }

--- a/src/ast_dumper.cpp
+++ b/src/ast_dumper.cpp
@@ -104,6 +104,26 @@ void AstDumper::Visit(const ArrDeclNode& arr_decl) {
   indenter_.DecreaseLevel();
 }
 
+void AstDumper::Visit(const RecordDeclNode& record_decl) {
+  std::string id = "";
+  if (!record_decl.id.empty()) {
+    id += " " + record_decl.id;
+  }
+  std::cout << indenter_.Indent() << "RecordDeclNode <" << record_decl.loc
+            << "> " << record_decl.type->ToString() << id << " definition\n";
+
+  indenter_.IncreaseLevel();
+  for (const auto& field : record_decl.field_list) {
+    field->Accept(*this);
+  }
+  indenter_.DecreaseLevel();
+}
+
+void AstDumper::Visit(const FieldNode& field) {
+  std::cout << indenter_.Indent() << "FieldNode <" << field.loc << "> "
+            << field.id << ": " << field.type->ToString() << '\n';
+}
+
 void AstDumper::Visit(const ParamNode& parameter) {
   std::cout << indenter_.Indent() << "ParamNode <" << parameter.loc << "> "
             << parameter.id << ": " << parameter.type->ToString() << '\n';

--- a/src/ast_dumper.cpp
+++ b/src/ast_dumper.cpp
@@ -113,7 +113,7 @@ void AstDumper::Visit(const RecordDeclNode& record_decl) {
             << "> " << record_decl.type->ToString() << id << " definition\n";
 
   indenter_.IncreaseLevel();
-  for (const auto& field : record_decl.field_list) {
+  for (const auto& field : record_decl.fields) {
     field->Accept(*this);
   }
   indenter_.DecreaseLevel();

--- a/src/qbe_ir_generator.cpp
+++ b/src/qbe_ir_generator.cpp
@@ -192,6 +192,10 @@ void QbeIrGenerator::Visit(const ArrDeclNode& arr_decl) {
   }
 }
 
+void QbeIrGenerator::Visit(const RecordDeclNode& struct_def) {}
+
+void QbeIrGenerator::Visit(const FieldNode& field) {}
+
 void QbeIrGenerator::Visit(const ParamNode& parameter) {
   int id_num = NextLocalNum();
   // TODO: support different data types

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -6,8 +6,6 @@
 #include <utility>
 #include <vector>
 
-#include "ast.hpp"
-
 bool Type::IsEqual(PrimitiveType that) const noexcept {
   return IsEqual(PrimType{that});
 }
@@ -180,11 +178,7 @@ std::size_t StructType::size() const {
 }
 
 std::string StructType::ToString() const {
-  if (field_types_.size() > 0) {
-    return "definition";
-  }
-
-  return "";
+  return "struct";
 }
 
 std::unique_ptr<Type> StructType::Clone() const {
@@ -209,11 +203,7 @@ std::size_t UnionType::size() const {
 }
 
 std::string UnionType::ToString() const {
-  if (field_types_.size() > 0) {
-    return "definition";
-  }
-
-  return "";
+  return "union";
 }
 
 std::unique_ptr<Type> UnionType::Clone() const {

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -78,6 +78,14 @@ void TypeChecker::Visit(ArrDeclNode& arr_decl) {
   // TODO: Check initializer type
 }
 
+void TypeChecker::Visit(RecordDeclNode& struct_def) {
+  // TODO: Store record declaration in a new table under scope.
+}
+
+void TypeChecker::Visit(FieldNode& field) {
+  // TODO: Store field in corresponding record declaration, e.g., struct, union.
+}
+
 void TypeChecker::Visit(ParamNode& parameter) {
   if (env_.Probe(parameter.id)) {
     // TODO: redefinition of 'id'

--- a/test/typecheck/struct.c
+++ b/test/typecheck/struct.c
@@ -1,0 +1,17 @@
+int main() {
+  struct ss;
+
+  struct birth {
+    int date;
+    int month;
+    int year;
+  };
+
+  struct {
+    int quarter;
+    int dime;
+    int penny;
+  };
+
+  return 0;
+}

--- a/test/typecheck/struct.exp
+++ b/test/typecheck/struct.exp
@@ -1,0 +1,14 @@
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int ()
+    CompoundStmtNode <1:12>
+      RecordDeclNode <2:10> struct ss definition
+      RecordDeclNode <4:10> struct birth definition
+        FieldNode <5:9> date: int
+        FieldNode <6:9> month: int
+        FieldNode <7:9> year: int
+      RecordDeclNode <10:9> struct definition
+        FieldNode <11:9> quarter: int
+        FieldNode <12:9> dime: int
+        FieldNode <13:9> penny: int
+      ReturnStmtNode <16:3>
+        IntConstExprNode <16:10> 0: int

--- a/test/typecheck/union.c
+++ b/test/typecheck/union.c
@@ -1,0 +1,19 @@
+int main() {
+  union u;
+
+  union shape {
+    int square;
+    int circle;
+    int triangle;
+  };
+
+  union {
+    int a;
+    int b;
+    int c;
+    int d;
+    int e;
+  };
+
+  return 0;
+}

--- a/test/typecheck/union.exp
+++ b/test/typecheck/union.exp
@@ -1,0 +1,16 @@
+ProgramNode <1:1>
+  FuncDefNode <1:5> main: int ()
+    CompoundStmtNode <1:12>
+      RecordDeclNode <2:9> union u definition
+      RecordDeclNode <4:9> union shape definition
+        FieldNode <5:9> square: int
+        FieldNode <6:9> circle: int
+        FieldNode <7:9> triangle: int
+      RecordDeclNode <10:8> union definition
+        FieldNode <11:9> a: int
+        FieldNode <12:9> b: int
+        FieldNode <13:9> c: int
+        FieldNode <14:9> d: int
+        FieldNode <15:9> e: int
+      ReturnStmtNode <18:3>
+        IntConstExprNode <18:10> 0: int


### PR DESCRIPTION
This PR parses struct and union type declaration.

- A new declaration node `RecordDeclNode` for struct and union.
- A new declaration node `FieldNode` for fields of struct or union.
- Introduces `StructType` and `UnionType`.

TODO: Just like we discusses, I will create a new symbol table (probably the same members but different name) under scope in the future PRs.

The output format is copied from clang:

```
$ clang -Xclang -ast-dump test/typecheck/struct.c
-FunctionDecl 0x55bf9d309910 <test/typecheck/struct.c:1:1, line:17:1> line:1:5 main 'int ()'
  `-CompoundStmt 0x55bf9d309ed0 <col:12, line:17:1>
    |-DeclStmt 0x55bf9d309aa0 <line:2:3, col:12>
    | `-RecordDecl 0x55bf9d3099f8 <col:3, col:10> col:10 struct ss
    |-DeclStmt 0x55bf9d309c98 <line:4:3, line:8:4>
    | `-RecordDecl 0x55bf9d309ab8 <line:4:3, line:8:3> line:4:10 struct birth definition
    |   |-FieldDecl 0x55bf9d309b78 <line:5:5, col:9> col:9 date 'int'
    |   |-FieldDecl 0x55bf9d309be0 <line:6:5, col:9> col:9 month 'int'
    |   `-FieldDecl 0x55bf9d309c48 <line:7:5, col:9> col:9 year 'int'
    |-DeclStmt 0x55bf9d309e88 <line:10:3, line:14:4>
    | `-RecordDecl 0x55bf9d309cb0 <line:10:3, line:14:3> line:10:3 struct definition
    |   |-FieldDecl 0x55bf9d309d68 <line:11:5, col:9> col:9 quarter 'int'
    |   |-FieldDecl 0x55bf9d309dd0 <line:12:5, col:9> col:9 dime 'int'
    |   `-FieldDecl 0x55bf9d309e38 <line:13:5, col:9> col:9 penny 'int'
    `-ReturnStmt 0x55bf9d309ec0 <line:16:3, col:10>
      `-IntegerLiteral 0x55bf9d309ea0 <col:10> 'int' 0
```

Related to: #140 