### PR TITLE
Decay parameter of array or function type

### DIFF
--- a/test/typecheck/array_param.c
+++ b/test/typecheck/array_param.c
@@ -1,0 +1,11 @@
+// Any parameter of array type is adjusted to the corresponding pointer type.
+int func(int a[3]) {
+  // do nothing; only testing the type of a
+  return 0;
+}
+
+int main() {
+  int a[3] = {1, 2, 3};
+  func(a);
+  return 0;
+}

--- a/test/typecheck/array_param.exp
+++ b/test/typecheck/array_param.exp
@@ -1,0 +1,19 @@
+ProgramNode <1:1>
+  FuncDefNode <2:5> func: int (int*)
+    ParamNode <2:14> a: int*
+    CompoundStmtNode <2:20>
+      ReturnStmtNode <4:3>
+        IntConstExprNode <4:10> 0: int
+  FuncDefNode <7:5> main: int ()
+    CompoundStmtNode <7:12>
+      ArrDeclNode <8:7> a: int[3]
+        IntConstExprNode <8:15> 1: int
+        IntConstExprNode <8:18> 2: int
+        IntConstExprNode <8:21> 3: int
+      ExprStmtNode <9:3>
+        FuncCallExprNode <9:3> int
+          IdExprNode <9:3> func: int (int*)
+          ArgExprNode <9:8> int[3]
+            IdExprNode <9:8> a: int[3]
+      ReturnStmtNode <10:3>
+        IntConstExprNode <10:10> 0: int

--- a/test/typecheck/func_pointer_param.c
+++ b/test/typecheck/func_pointer_param.c
@@ -6,8 +6,16 @@ int call(int (*p)(int, int), int a, int b) {
   return p(a, b);
 }
 
+// Any parameter of function type is adjusted to the corresponding pointer type.
+int call_decay(int p(int, int), int a, int b) {
+  // do nothing; only testing the type of p
+  return 0;
+}
+
 int main() {
   int (*c)(int (*)(int, int), int, int) = call;
+  c(add, 1, 2);
+  c = call_decay;
   c(add, 1, 2);
   return 0;
 }

--- a/test/typecheck/func_pointer_param.exp
+++ b/test/typecheck/func_pointer_param.exp
@@ -19,18 +19,38 @@ ProgramNode <1:1>
             IdExprNode <6:12> a: int
           ArgExprNode <6:15> int
             IdExprNode <6:15> b: int
-  FuncDefNode <9:5> main: int ()
-    CompoundStmtNode <9:12>
-      VarDeclNode <10:9> c: int (*)(int (*)(int, int), int, int)
-        IdExprNode <10:43> call: int (int (*)(int, int), int, int)
-      ExprStmtNode <11:3>
-        FuncCallExprNode <11:3> int
-          IdExprNode <11:3> c: int (*)(int (*)(int, int), int, int)
-          ArgExprNode <11:5> int (int, int)
-            IdExprNode <11:5> add: int (int, int)
-          ArgExprNode <11:10> int
-            IntConstExprNode <11:10> 1: int
-          ArgExprNode <11:13> int
-            IntConstExprNode <11:13> 2: int
+  FuncDefNode <10:5> call_decay: int (int (*)(int, int), int, int)
+    ParamNode <10:20> p: int (*)(int, int)
+    ParamNode <10:37> a: int
+    ParamNode <10:44> b: int
+    CompoundStmtNode <10:47>
       ReturnStmtNode <12:3>
         IntConstExprNode <12:10> 0: int
+  FuncDefNode <15:5> main: int ()
+    CompoundStmtNode <15:12>
+      VarDeclNode <16:9> c: int (*)(int (*)(int, int), int, int)
+        IdExprNode <16:43> call: int (int (*)(int, int), int, int)
+      ExprStmtNode <17:3>
+        FuncCallExprNode <17:3> int
+          IdExprNode <17:3> c: int (*)(int (*)(int, int), int, int)
+          ArgExprNode <17:5> int (int, int)
+            IdExprNode <17:5> add: int (int, int)
+          ArgExprNode <17:10> int
+            IntConstExprNode <17:10> 1: int
+          ArgExprNode <17:13> int
+            IntConstExprNode <17:13> 2: int
+      ExprStmtNode <18:3>
+        SimpleAssignmentExprNode <18:5> int (*)(int (*)(int, int), int, int)
+          IdExprNode <18:3> c: int (*)(int (*)(int, int), int, int)
+          IdExprNode <18:7> call_decay: int (int (*)(int, int), int, int)
+      ExprStmtNode <19:3>
+        FuncCallExprNode <19:3> int
+          IdExprNode <19:3> c: int (*)(int (*)(int, int), int, int)
+          ArgExprNode <19:5> int (int, int)
+            IdExprNode <19:5> add: int (int, int)
+          ArgExprNode <19:10> int
+            IntConstExprNode <19:10> 1: int
+          ArgExprNode <19:13> int
+            IntConstExprNode <19:13> 2: int
+      ReturnStmtNode <20:3>
+        IntConstExprNode <20:10> 0: int


### PR DESCRIPTION
A function can have its parameter be of an array type:

```c
int func(int arr[], int size);
```

The type of the first parameter `arr` is actually adjusted, or, say, decayed to a simple pointer type:

```c
int func(int* arr, int size);
```

Similarly, a parameter of function type is decayed to a pointer to such a function type.
Clang also reflects this decay in its AST dumping:

```
`-FunctionDecl 0x12db460 <decay.c:1:1, col:29> col:5 func 'int (int *, int)'
  |-ParmVarDecl 0x12db2c0 <col:10, col:18> col:14 arr 'int *':'int *'
  `-ParmVarDecl 0x12db340 <col:21, col:25> col:25 size 'int'
```