### PR TITLE
Postfix record member access expression

### DIFF
--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -520,6 +520,20 @@ struct PostfixArithExprNode : public ExprNode {
   std::unique_ptr<ExprNode> operand;
 };
 
+/// @brief A postfix expression that designates a member of struct or union.
+struct RecordMemExprNode : public ExprNode {
+  RecordMemExprNode(Location loc, PostfixOperator op,
+                    std::unique_ptr<ExprNode> expr, std::string id)
+      : ExprNode{loc}, op{op}, expr{std::move(expr)}, id{std::move(id)} {}
+
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
+
+  PostfixOperator op;
+  std::unique_ptr<ExprNode> expr;
+  std::string id;
+};
+
 struct UnaryExprNode : public ExprNode {
   UnaryExprNode(Location loc, UnaryOperator op,
                 std::unique_ptr<ExprNode> operand)

--- a/include/ast_dumper.hpp
+++ b/include/ast_dumper.hpp
@@ -41,6 +41,7 @@ class AstDumper : public NonModifyingVisitor {
   void Visit(const CondExprNode&) override;
   void Visit(const FuncCallExprNode&) override;
   void Visit(const PostfixArithExprNode&) override;
+  void Visit(const RecordMemExprNode&) override;
   void Visit(const UnaryExprNode&) override;
   void Visit(const BinaryExprNode&) override;
   void Visit(const SimpleAssignmentExprNode&) override;

--- a/include/operator.hpp
+++ b/include/operator.hpp
@@ -39,6 +39,8 @@ enum class UnaryOperator : std::uint8_t {
 enum class PostfixOperator : std::uint8_t {
   kIncr,
   kDecr,
+  kDot,
+  kArrow,
 };
 
 #endif

--- a/include/qbe_ir_generator.hpp
+++ b/include/qbe_ir_generator.hpp
@@ -48,6 +48,7 @@ class QbeIrGenerator : public NonModifyingVisitor {
   void Visit(const CondExprNode&) override;
   void Visit(const FuncCallExprNode&) override;
   void Visit(const PostfixArithExprNode&) override;
+  void Visit(const RecordMemExprNode&) override;
   void Visit(const UnaryExprNode&) override;
   void Visit(const BinaryExprNode&) override;
   void Visit(const SimpleAssignmentExprNode&) override;

--- a/include/type.hpp
+++ b/include/type.hpp
@@ -186,8 +186,8 @@ struct Field {
 class RecordType : public Type {
  public:
   /// @return The type id.
-  virtual std::string id()
-      const noexcept = 0;  // // NOLINT(readability-identifier-naming)
+  virtual std::string id()  // NOLINT(readability-identifier-naming)
+      const noexcept = 0;
   /// @brief Checks if `id` is a member of the record type.
   virtual bool IsMember(const std::string& id) const noexcept = 0;
   /// @return The type of a member in struct or union. The unknown type if the
@@ -203,8 +203,8 @@ class StructType : public RecordType {
   StructType(std::string id, std::vector<std::unique_ptr<Field>> fields)
       : id_{std::move(id)}, fields_{std::move(fields)} {}
 
-  std::string id()
-      const noexcept override;  // NOLINT(readability-identifier-naming)
+  std::string id()  // NOLINT(readability-identifier-naming)
+      const noexcept override;
   bool IsMember(const std::string& id) const noexcept override;
   std::unique_ptr<Type> MemberType(
       const std::string& id) const noexcept override;
@@ -230,8 +230,8 @@ class UnionType : public RecordType {
   UnionType(std::string id, std::vector<std::unique_ptr<Field>> fields)
       : id_{std::move(id)}, fields_{std::move(fields)} {}
 
-  std::string id()
-      const noexcept override;  // NOLINT(readability-identifier-naming)
+  std::string id()  // NOLINT(readability-identifier-naming)
+      const noexcept override;
   bool IsMember(const std::string& id) const noexcept override;
   std::unique_ptr<Type> MemberType(
       const std::string& id) const noexcept override;

--- a/include/type.hpp
+++ b/include/type.hpp
@@ -185,8 +185,13 @@ struct Field {
 
 class RecordType : public Type {
  public:
-  virtual std::string GetId() const noexcept = 0;
+  /// @return The type id.
+  virtual std::string id()
+      const noexcept = 0;  // // NOLINT(readability-identifier-naming)
+  /// @brief Checks if `id` is a member of the record type.
   virtual bool IsMember(const std::string& id) const noexcept = 0;
+  /// @return The type of a member in struct or union. The unknown type if the
+  /// `id` is not a member of the record type.
   virtual std::unique_ptr<Type> MemberType(
       const std::string& id) const noexcept = 0;
 };
@@ -198,7 +203,8 @@ class StructType : public RecordType {
   StructType(std::string id, std::vector<std::unique_ptr<Field>> fields)
       : id_{std::move(id)}, fields_{std::move(fields)} {}
 
-  std::string GetId() const noexcept override;
+  std::string id()
+      const noexcept override;  // NOLINT(readability-identifier-naming)
   bool IsMember(const std::string& id) const noexcept override;
   std::unique_ptr<Type> MemberType(
       const std::string& id) const noexcept override;
@@ -224,7 +230,8 @@ class UnionType : public RecordType {
   UnionType(std::string id, std::vector<std::unique_ptr<Field>> fields)
       : id_{std::move(id)}, fields_{std::move(fields)} {}
 
-  std::string GetId() const noexcept override;
+  std::string id()
+      const noexcept override;  // NOLINT(readability-identifier-naming)
   bool IsMember(const std::string& id) const noexcept override;
   std::unique_ptr<Type> MemberType(
       const std::string& id) const noexcept override;

--- a/include/type.hpp
+++ b/include/type.hpp
@@ -185,6 +185,7 @@ struct Field {
 
 class RecordType : public Type {
  public:
+  virtual std::string GetId() const noexcept = 0;
   virtual bool IsMember(const std::string& id) const noexcept = 0;
   virtual std::unique_ptr<Type> MemberType(
       const std::string& id) const noexcept = 0;
@@ -197,6 +198,7 @@ class StructType : public RecordType {
   StructType(std::string id, std::vector<std::unique_ptr<Field>> fields)
       : id_{std::move(id)}, fields_{std::move(fields)} {}
 
+  std::string GetId() const noexcept override;
   bool IsMember(const std::string& id) const noexcept override;
   std::unique_ptr<Type> MemberType(
       const std::string& id) const noexcept override;
@@ -222,6 +224,7 @@ class UnionType : public RecordType {
   UnionType(std::string id, std::vector<std::unique_ptr<Field>> fields)
       : id_{std::move(id)}, fields_{std::move(fields)} {}
 
+  std::string GetId() const noexcept override;
   bool IsMember(const std::string& id) const noexcept override;
   std::unique_ptr<Type> MemberType(
       const std::string& id) const noexcept override;

--- a/include/type.hpp
+++ b/include/type.hpp
@@ -183,12 +183,23 @@ struct Field {
       : id{std::move(id)}, type{std::move(type)} {}
 };
 
-class StructType : public Type {
+class RecordType : public Type {
+ public:
+  virtual bool IsMember(const std::string& id) const noexcept = 0;
+  virtual std::unique_ptr<Type> MemberType(
+      const std::string& id) const noexcept = 0;
+};
+
+class StructType : public RecordType {
  public:
   /// @param id The identifier of the struct type. May be empty ("") for unnamed
   /// structs.
   StructType(std::string id, std::vector<std::unique_ptr<Field>> fields)
       : id_{std::move(id)}, fields_{std::move(fields)} {}
+
+  bool IsMember(const std::string& id) const noexcept override;
+  std::unique_ptr<Type> MemberType(
+      const std::string& id) const noexcept override;
 
   bool IsStruct() const noexcept override {
     return true;
@@ -204,12 +215,16 @@ class StructType : public Type {
   std::vector<std::unique_ptr<Field>> fields_;
 };
 
-class UnionType : public Type {
+class UnionType : public RecordType {
  public:
   /// @param id The identifier of the union type. May be empty ("") for unnamed
   /// unions.
   UnionType(std::string id, std::vector<std::unique_ptr<Field>> fields)
       : id_{std::move(id)}, fields_{std::move(fields)} {}
+
+  bool IsMember(const std::string& id) const noexcept override;
+  std::unique_ptr<Type> MemberType(
+      const std::string& id) const noexcept override;
 
   bool IsUnion() const noexcept override {
     return true;

--- a/include/type.hpp
+++ b/include/type.hpp
@@ -174,12 +174,21 @@ class FuncType : public Type {
   bool ConvertibleHook_(const Type& that) const noexcept override;
 };
 
+/// @brief Field stores the name and the type of a member in struct or union.
+struct Field {
+  std::string id;
+  std::unique_ptr<Type> type;
+
+  Field(std::string id, std::unique_ptr<Type> type)
+      : id{std::move(id)}, type{std::move(type)} {}
+};
+
 class StructType : public Type {
  public:
   /// @param id The identifier of the struct type. May be empty ("") for unnamed
   /// structs.
-  StructType(std::string id, std::vector<std::unique_ptr<Type>> field_types)
-      : id_{std::move(id)}, field_types_{std::move(field_types)} {}
+  StructType(std::string id, std::vector<std::unique_ptr<Field>> fields)
+      : id_{std::move(id)}, fields_{std::move(fields)} {}
 
   bool IsStruct() const noexcept override {
     return true;
@@ -192,15 +201,15 @@ class StructType : public Type {
 
  private:
   std::string id_;
-  std::vector<std::unique_ptr<Type>> field_types_;
+  std::vector<std::unique_ptr<Field>> fields_;
 };
 
 class UnionType : public Type {
  public:
   /// @param id The identifier of the union type. May be empty ("") for unnamed
   /// unions.
-  UnionType(std::string id, std::vector<std::unique_ptr<Type>> field_types)
-      : id_{std::move(id)}, field_types_{std::move(field_types)} {}
+  UnionType(std::string id, std::vector<std::unique_ptr<Field>> fields)
+      : id_{std::move(id)}, fields_{std::move(fields)} {}
 
   bool IsUnion() const noexcept override {
     return true;
@@ -213,7 +222,7 @@ class UnionType : public Type {
 
  private:
   std::string id_;
-  std::vector<std::unique_ptr<Type>> field_types_;
+  std::vector<std::unique_ptr<Field>> fields_;
 };
 
 #endif  // TYPE_HPP_

--- a/include/type_checker.hpp
+++ b/include/type_checker.hpp
@@ -44,6 +44,7 @@ class TypeChecker : public ModifyingVisitor {
   void Visit(CondExprNode&) override;
   void Visit(FuncCallExprNode&) override;
   void Visit(PostfixArithExprNode&) override;
+  void Visit(RecordMemExprNode&) override;
   void Visit(UnaryExprNode&) override;
   void Visit(BinaryExprNode&) override;
   void Visit(SimpleAssignmentExprNode&) override;

--- a/include/visitor.hpp
+++ b/include/visitor.hpp
@@ -46,6 +46,7 @@ struct ArrSubExprNode;
 struct CondExprNode;
 struct FuncCallExprNode;
 struct PostfixArithExprNode;
+struct RecordMemExprNode;
 struct UnaryExprNode;
 struct BinaryExprNode;
 struct AssignmentExprNode;
@@ -107,6 +108,7 @@ class Visitor {
   virtual void Visit(CondMut<CondExprNode>&){};
   virtual void Visit(CondMut<FuncCallExprNode>&){};
   virtual void Visit(CondMut<PostfixArithExprNode>&){};
+  virtual void Visit(CondMut<RecordMemExprNode>&){};
   virtual void Visit(CondMut<UnaryExprNode>&){};
   virtual void Visit(CondMut<BinaryExprNode>&){};
   virtual void Visit(CondMut<AssignmentExprNode>&){};

--- a/lexer.l
+++ b/lexer.l
@@ -49,6 +49,7 @@ integer [0-9]+
 
 "," { return yy::parser::make_COMMA(yylloc); }
 "." { return yy::parser::make_DOT(yylloc); }
+"->" { return yy::parser::make_ARROW(yylloc); }
 
   /* operators */
 "-" { return yy::parser::make_MINUS(yylloc); }

--- a/parser.y
+++ b/parser.y
@@ -274,8 +274,8 @@ postfix_expr: primary_expr { $$ = $1; }
   | postfix_expr INCR { $$ = std::make_unique<PostfixArithExprNode>(Loc(@1), PostfixOperator::kIncr, $1); }
   | postfix_expr DECR { $$ = std::make_unique<PostfixArithExprNode>(Loc(@1), PostfixOperator::kDecr, $1); }
   /* 6.5.2.3 Structure and union members */
-  | postfix_expr DOT ID
-  | postfix_expr ARROW ID
+  | postfix_expr DOT ID { $$ = std::make_unique<RecordMemExprNode>(Loc(@1), PostfixOperator::kDot, $1, $3); }
+  | postfix_expr ARROW ID { $$ = std::make_unique<RecordMemExprNode>(Loc(@1), PostfixOperator::kArrow, $1, $3); }
   ;
 
 /* 6.5.3 Unary operators */

--- a/parser.y
+++ b/parser.y
@@ -497,9 +497,10 @@ struct_or_union_specifier: struct_or_union id_opt LEFT_CURLY struct_declaration_
     auto type = $1;
     auto decl_id = $2;
     auto field_list = $4;
-    auto field_types = std::vector<std::unique_ptr<Type>>{};
+    auto fields = std::vector<std::unique_ptr<Field>>{};
     for (const auto& field : field_list) {
-      field_types.push_back(field->type->Clone());
+      auto field_node = std::make_unique<Field>(field->id, field->type->Clone());
+      fields.push_back(std::move(field_node));
     }
 
     auto type_id = decl_id ? decl_id->id : "";
@@ -515,7 +516,7 @@ struct_or_union_specifier: struct_or_union id_opt LEFT_CURLY struct_declaration_
     auto type = $1;
     auto decl_id = $2;
     auto field_list = std::vector<std::unique_ptr<FieldNode>>{};
-    auto field_types = std::vector<std::unique_ptr<Type>>{};
+    auto fields = std::vector<std::unique_ptr<Field>>{};
 
     if (type->IsStruct()) {
       type = std::make_unique<StructType>(decl_id, std::move(field_types));
@@ -572,12 +573,12 @@ id_opt: ID {
   ;
 
 struct_or_union: STRUCT {
-    auto field_types = std::vector<std::unique_ptr<Type>>{};
-    $$ = std::make_unique<StructType>("", std::move(field_types));
+    auto fields = std::vector<std::unique_ptr<Field>>{};
+    $$ = std::make_unique<StructType>("", std::move(fields));
   }
   | UNION {
-    auto field_types = std::vector<std::unique_ptr<Type>>{};
-    $$ = std::make_unique<UnionType>("", std::move(field_types));
+    auto fields = std::vector<std::unique_ptr<Field>>{};
+    $$ = std::make_unique<UnionType>("", std::move(fields));
   }
   ;
 

--- a/parser.y
+++ b/parser.y
@@ -505,9 +505,9 @@ struct_or_union_specifier: struct_or_union id_opt LEFT_CURLY struct_declaration_
 
     auto type_id = decl_id ? decl_id->id : "";
     if (type->IsStruct()) {
-      type = std::make_unique<StructType>(type_id, std::move(field_types));
+      type = std::make_unique<StructType>(type_id, std::move(fields));
     } else {
-      type = std::make_unique<UnionType>(type_id, std::move(field_types));
+      type = std::make_unique<UnionType>(type_id, std::move(fields));
     }
 
     $$ = std::make_unique<RecordDeclNode>(Loc(@2), std::move(type_id), std::move(type), std::move(field_list));
@@ -519,9 +519,9 @@ struct_or_union_specifier: struct_or_union id_opt LEFT_CURLY struct_declaration_
     auto fields = std::vector<std::unique_ptr<Field>>{};
 
     if (type->IsStruct()) {
-      type = std::make_unique<StructType>(decl_id, std::move(field_types));
+      type = std::make_unique<StructType>(decl_id, std::move(fields));
     } else {
-      type = std::make_unique<UnionType>(decl_id, std::move(field_types));
+      type = std::make_unique<UnionType>(decl_id, std::move(fields));
     }
 
     $$ = std::make_unique<RecordDeclNode>(Loc(@2), std::move(decl_id), std::move(type), std::move(field_list));

--- a/parser.y
+++ b/parser.y
@@ -79,7 +79,7 @@ std::unique_ptr<Type> ResolveType(std::unique_ptr<Type> resolved_type,
 
 %token MINUS PLUS STAR DIV MOD ASSIGN
 %token EXCLAMATION TILDE AMPERSAND QUESTION
-%token COMMA DOT SEMICOLON COLON
+%token COMMA DOT ARROW SEMICOLON COLON
 // (), {}, []
 %token LEFT_PAREN RIGHT_PAREN LEFT_CURLY RIGHT_CURLY LEFT_SQUARE RIGHT_SQUARE
 
@@ -273,6 +273,9 @@ postfix_expr: primary_expr { $$ = $1; }
   /* 6.5.2.4 Postfix increment and decrement operators */
   | postfix_expr INCR { $$ = std::make_unique<PostfixArithExprNode>(Loc(@1), PostfixOperator::kIncr, $1); }
   | postfix_expr DECR { $$ = std::make_unique<PostfixArithExprNode>(Loc(@1), PostfixOperator::kDecr, $1); }
+  /* 6.5.2.3 Structure and union members */
+  | postfix_expr DOT ID
+  | postfix_expr ARROW ID
   ;
 
 /* 6.5.3 Unary operators */

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -334,6 +334,14 @@ void PostfixArithExprNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
+void RecordMemExprNode::Accept(NonModifyingVisitor& v) const {
+  v.Visit(*this);
+}
+
+void RecordMemExprNode::Accept(ModifyingVisitor& v) {
+  v.Visit(*this);
+}
+
 void UnaryExprNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }

--- a/src/ast_dumper.cpp
+++ b/src/ast_dumper.cpp
@@ -307,7 +307,8 @@ void AstDumper::Visit(const ExprStmtNode& expr_stmt) {
 }
 
 void AstDumper::Visit(const InitExprNode& init_expr) {
-  std::cout << indenter_.Indent() << "InitExprNode <" << init_expr.loc << ">\n";
+  std::cout << indenter_.Indent() << "InitExprNode <" << init_expr.loc << "> "
+            << init_expr.type->ToString() << "\n";
   indenter_.IncreaseLevel();
   for (const auto& des : init_expr.des) {
     des->Accept(*this);

--- a/src/ast_dumper.cpp
+++ b/src/ast_dumper.cpp
@@ -390,7 +390,14 @@ void AstDumper::Visit(const PostfixArithExprNode& postfix_expr) {
   indenter_.DecreaseLevel();
 }
 
-void AstDumper::Visit(const RecordMemExprNode& mem_expr) {}
+void AstDumper::Visit(const RecordMemExprNode& mem_expr) {
+  std::cout << indenter_.Indent() << "RecordMemExprNode <" << mem_expr.loc
+            << "> " << GetPostfixOperator(mem_expr.op) << mem_expr.id << ": "
+            << mem_expr.type->ToString() << '\n';
+  indenter_.IncreaseLevel();
+  mem_expr.expr->Accept(*this);
+  indenter_.DecreaseLevel();
+}
 
 void AstDumper::Visit(const UnaryExprNode& unary_expr) {
   std::cout << indenter_.Indent() << "UnaryExprNode <" << unary_expr.loc << "> "

--- a/src/ast_dumper.cpp
+++ b/src/ast_dumper.cpp
@@ -85,6 +85,10 @@ std::string GetPostfixOperator(PostfixOperator op) {
       return "++";
     case PostfixOperator::kDecr:
       return "--";
+    case PostfixOperator::kDot:
+      return ".";
+    case PostfixOperator::kArrow:
+      return "->";
     default:
       return "Unknown";
   }
@@ -385,6 +389,8 @@ void AstDumper::Visit(const PostfixArithExprNode& postfix_expr) {
   postfix_expr.operand->Accept(*this);
   indenter_.DecreaseLevel();
 }
+
+void AstDumper::Visit(const RecordMemExprNode& mem_expr) {}
 
 void AstDumper::Visit(const UnaryExprNode& unary_expr) {
   std::cout << indenter_.Indent() << "UnaryExprNode <" << unary_expr.loc << "> "

--- a/src/qbe_ir_generator.cpp
+++ b/src/qbe_ir_generator.cpp
@@ -765,6 +765,8 @@ void QbeIrGenerator::Visit(const PostfixArithExprNode& postfix_expr) {
               FuncScopeTemp{id_to_num.at(id_expr->id)});
 }
 
+void QbeIrGenerator::Visit(const RecordMemExprNode& mem_expr) {}
+
 void QbeIrGenerator::Visit(const UnaryExprNode& unary_expr) {
   unary_expr.operand->Accept(*this);
   switch (unary_expr.op) {

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -154,6 +154,10 @@ std::unique_ptr<Type> FuncType::Clone() const {
                                     std::move(cloned_param_types));
 }
 
+std::string StructType::GetId() const noexcept {
+  return id_;
+}
+
 bool StructType::IsMember(const std::string& id) const noexcept {
   for (const auto& field : fields_) {
     if (field->id == id) {
@@ -214,6 +218,10 @@ std::unique_ptr<Type> StructType::Clone() const {
     cloned_fields.push_back(std::move(cloned_field));
   }
   return std::make_unique<StructType>(id_, std::move(cloned_fields));
+}
+
+std::string UnionType::GetId() const noexcept {
+  return id_;
 }
 
 bool UnionType::IsMember(const std::string& id) const noexcept {

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -154,6 +154,27 @@ std::unique_ptr<Type> FuncType::Clone() const {
                                     std::move(cloned_param_types));
 }
 
+bool StructType::IsMember(const std::string& id) const noexcept {
+  for (const auto& field : fields_) {
+    if (field->id == id) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+std::unique_ptr<Type> StructType::MemberType(
+    const std::string& id) const noexcept {
+  for (const auto& field : fields_) {
+    if (field->id == id) {
+      return std::move(field->type->Clone());
+    }
+  }
+
+  return std::make_unique<PrimType>(PrimitiveType::kUnknown);
+}
+
 bool StructType::IsEqual(const Type& that) const noexcept {
   if (const auto* that_struct = dynamic_cast<const StructType*>(&that)) {
     if (that_struct->size() != size()) {
@@ -193,6 +214,27 @@ std::unique_ptr<Type> StructType::Clone() const {
     cloned_fields.push_back(std::move(cloned_field));
   }
   return std::make_unique<StructType>(id_, std::move(cloned_fields));
+}
+
+bool UnionType::IsMember(const std::string& id) const noexcept {
+  for (const auto& field : fields_) {
+    if (field->id == id) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+std::unique_ptr<Type> UnionType::MemberType(
+    const std::string& id) const noexcept {
+  for (const auto& field : fields_) {
+    if (field->id == id) {
+      return std::move(field->type->Clone());
+    }
+  }
+
+  return std::make_unique<PrimType>(PrimitiveType::kUnknown);
 }
 
 bool UnionType::IsEqual(const Type& that) const noexcept {

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -159,8 +159,8 @@ bool StructType::IsEqual(const Type& that) const noexcept {
     if (that_struct->size() != size()) {
       return false;
     }
-    for (auto i = std::size_t{0}, e = field_types_.size(); i < e; ++i) {
-      if (!that_struct->field_types_.at(i)->IsEqual(*field_types_.at(i))) {
+    for (auto i = std::size_t{0}, e = fields_.size(); i < e; ++i) {
+      if (!that_struct->fields_.at(i)->type->IsEqual(*fields_.at(i)->type)) {
         return false;
       }
     }
@@ -172,8 +172,8 @@ bool StructType::IsEqual(const Type& that) const noexcept {
 std::size_t StructType::size() const {
   // TODO: There may be unnamed padding at the end of a structure or union.
   auto size = std::size_t{0};
-  for (const auto& field_type : field_types_) {
-    size += field_type->size();
+  for (const auto& field : fields_) {
+    size += field->type->size();
   }
   return size;
 }
@@ -186,11 +186,13 @@ std::string StructType::ToString() const {
 }
 
 std::unique_ptr<Type> StructType::Clone() const {
-  auto cloned_field_types = std::vector<std::unique_ptr<Type>>{};
-  for (const auto& field_type : field_types_) {
-    cloned_field_types.push_back(field_type->Clone());
+  auto cloned_fields = std::vector<std::unique_ptr<Field>>{};
+  for (const auto& field : fields_) {
+    auto cloned_field =
+        std::make_unique<Field>(field->id, field->type->Clone());
+    cloned_fields.push_back(std::move(cloned_field));
   }
-  return std::make_unique<StructType>(id_, std::move(cloned_field_types));
+  return std::make_unique<StructType>(id_, std::move(cloned_fields));
 }
 
 bool UnionType::IsEqual(const Type& that) const noexcept {
@@ -204,8 +206,8 @@ std::size_t UnionType::size() const {
   // The size of a union is sufficient to contain the largest of its members.
   // TODO: There may be unnamed padding at the end of a structure or union.
   auto size = std::size_t{0};
-  for (const auto& field_type : field_types_) {
-    size = std::max(size, field_type->size());
+  for (const auto& field : fields_) {
+    size = std::max(size, field->type->size());
   }
   return size;
 }
@@ -218,9 +220,11 @@ std::string UnionType::ToString() const {
 }
 
 std::unique_ptr<Type> UnionType::Clone() const {
-  auto cloned_field_types = std::vector<std::unique_ptr<Type>>{};
-  for (const auto& field_type : field_types_) {
-    cloned_field_types.push_back(field_type->Clone());
+  auto cloned_fields = std::vector<std::unique_ptr<Field>>{};
+  for (const auto& field : fields_) {
+    auto cloned_field =
+        std::make_unique<Field>(field->id, field->type->Clone());
+    cloned_fields.push_back(std::move(cloned_field));
   }
-  return std::make_unique<UnionType>(id_, std::move(cloned_field_types));
+  return std::make_unique<UnionType>(id_, std::move(cloned_fields));
 }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -154,7 +154,7 @@ std::unique_ptr<Type> FuncType::Clone() const {
                                     std::move(cloned_param_types));
 }
 
-std::string StructType::GetId() const noexcept {
+std::string StructType::id() const noexcept {
   return id_;
 }
 
@@ -172,7 +172,7 @@ std::unique_ptr<Type> StructType::MemberType(
     const std::string& id) const noexcept {
   for (const auto& field : fields_) {
     if (field->id == id) {
-      return std::move(field->type->Clone());
+      return field->type->Clone();
     }
   }
 
@@ -220,7 +220,7 @@ std::unique_ptr<Type> StructType::Clone() const {
   return std::make_unique<StructType>(id_, std::move(cloned_fields));
 }
 
-std::string UnionType::GetId() const noexcept {
+std::string UnionType::id() const noexcept {
   return id_;
 }
 
@@ -238,7 +238,7 @@ std::unique_ptr<Type> UnionType::MemberType(
     const std::string& id) const noexcept {
   for (const auto& field : fields_) {
     if (field->id == id) {
-      return std::move(field->type->Clone());
+      return field->type->Clone();
     }
   }
 

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -475,6 +475,8 @@ void TypeChecker::Visit(PostfixArithExprNode& postfix_expr) {
   postfix_expr.type = postfix_expr.operand->type->Clone();
 }
 
+void TypeChecker::Visit(RecordMemExprNode& mem_expr) {}
+
 void TypeChecker::Visit(UnaryExprNode& unary_expr) {
   unary_expr.operand->Accept(*this);
   switch (unary_expr.op) {

--- a/test/typecheck/array.exp
+++ b/test/typecheck/array.exp
@@ -29,15 +29,15 @@ ProgramNode <1:1>
         VarDeclNode <8:7> b: int
           IntConstExprNode <8:11> 0: int
         ArrDeclNode <8:14> c: int[4]
-          InitExprNode <8:22>
+          InitExprNode <8:22> int
             IntConstExprNode <8:22> 1: int
-          InitExprNode <8:22>
+          InitExprNode <8:22> int
             SimpleAssignmentExprNode <8:27> int
               IdExprNode <8:25> b: int
               IntConstExprNode <8:29> 2: int
-          InitExprNode <8:22>
+          InitExprNode <8:22> int
             IntConstExprNode <8:32> 3: int
-          InitExprNode <8:22>
+          InitExprNode <8:22> int
             IntConstExprNode <8:35> 4: int
       ReturnStmtNode <10:3>
         IntConstExprNode <10:10> 0: int

--- a/test/typecheck/array_param.exp
+++ b/test/typecheck/array_param.exp
@@ -8,11 +8,11 @@ ProgramNode <1:1>
     CompoundStmtNode <7:12>
       DeclStmtNode <8:3>
         ArrDeclNode <8:7> a: int[3]
-          InitExprNode <8:15>
+          InitExprNode <8:15> int
             IntConstExprNode <8:15> 1: int
-          InitExprNode <8:15>
+          InitExprNode <8:15> int
             IntConstExprNode <8:18> 2: int
-          InitExprNode <8:15>
+          InitExprNode <8:15> int
             IntConstExprNode <8:21> 3: int
       ExprStmtNode <9:3>
         FuncCallExprNode <9:3> int

--- a/test/typecheck/struct.c
+++ b/test/typecheck/struct.c
@@ -25,5 +25,7 @@ int main() {
 
   struct birth a, *b, c[3];
 
+  bd1.date;
+
   return 0;
 }

--- a/test/typecheck/struct.exp
+++ b/test/typecheck/struct.exp
@@ -48,5 +48,8 @@ ProgramNode <1:1>
         VarDeclNode <26:16> a: struct birth
         VarDeclNode <26:20> b: struct birth*
         ArrDeclNode <26:23> c: struct birth[3]
-      ReturnStmtNode <28:3>
-        IntConstExprNode <28:10> 0: int
+      ExprStmtNode <28:3>
+        RecordMemExprNode <28:3> .date: int
+          IdExprNode <28:3> bd1: struct birth
+      ReturnStmtNode <30:3>
+        IntConstExprNode <30:10> 0: int

--- a/test/typecheck/struct.exp
+++ b/test/typecheck/struct.exp
@@ -15,31 +15,31 @@ ProgramNode <1:1>
           FieldNode <13:9> penny: int
       DeclStmtNode <16:3>
         RecordVarDeclNode <16:16> bd1: struct birth
-          InitExprNode <17:5>
+          InitExprNode <17:5> int
             IdDesNode <17:6> date
             IntConstExprNode <17:13> 1: int
-          InitExprNode <17:5>
+          InitExprNode <17:5> int
             IdDesNode <18:6> month
             IntConstExprNode <18:14> 1: int
-          InitExprNode <17:5>
+          InitExprNode <17:5> int
             IdDesNode <19:6> year
             IntConstExprNode <19:13> 1995: int
       DeclStmtNode <22:3>
         RecordVarDeclNode <22:16> bd2: struct birth
-          InitExprNode <22:23>
+          InitExprNode <22:23> int
             IntConstExprNode <22:23> 3: int
-          InitExprNode <22:23>
+          InitExprNode <22:23> int
             IntConstExprNode <22:26> 3: int
-          InitExprNode <22:23>
+          InitExprNode <22:23> int
             IntConstExprNode <22:29> 1998: int
       DeclStmtNode <24:3>
         ArrDeclNode <24:16> bd3: struct birth[3]
-          InitExprNode <24:26>
+          InitExprNode <24:26> int
             ArrDesNode <24:27>
               IntConstExprNode <24:27> 0: int
             IdDesNode <24:30> date
             IntConstExprNode <24:37> 4: int
-          InitExprNode <24:26>
+          InitExprNode <24:26> int
             ArrDesNode <24:41>
               IntConstExprNode <24:41> 1: int
             IdDesNode <24:44> year

--- a/test/typecheck/union.c
+++ b/test/typecheck/union.c
@@ -24,5 +24,7 @@ int main() {
 
   union shape a, *b, c[3];
 
+  s.circle;
+
   return 0;
 }

--- a/test/typecheck/union.exp
+++ b/test/typecheck/union.exp
@@ -17,30 +17,30 @@ ProgramNode <1:1>
           FieldNode <15:9> e: int
       DeclStmtNode <20:3>
         RecordVarDeclNode <20:15> s: union shape
-          InitExprNode <20:20>
+          InitExprNode <20:20> int
             IntConstExprNode <20:20> 3: int
-          InitExprNode <20:20>
+          InitExprNode <20:20> int
             IntConstExprNode <20:23> 4: int
-          InitExprNode <20:20>
+          InitExprNode <20:20> int
             IntConstExprNode <20:26> 5: int
       DeclStmtNode <22:3>
         RecordVarDeclNode <22:15> circle: union shape
-          InitExprNode <22:25>
+          InitExprNode <22:25> int
             IdDesNode <22:26> circle
             IntConstExprNode <22:35> 1: int
       DeclStmtNode <23:3>
         ArrDeclNode <23:15> puzzles: union shape[3]
-          InitExprNode <23:29>
+          InitExprNode <23:29> int
             ArrDesNode <23:30>
               IntConstExprNode <23:30> 0: int
             IdDesNode <23:33> circle
             IntConstExprNode <23:42> 1: int
-          InitExprNode <23:29>
+          InitExprNode <23:29> int
             ArrDesNode <23:46>
               IntConstExprNode <23:46> 1: int
             IdDesNode <23:49> triangle
             IntConstExprNode <23:60> 2: int
-          InitExprNode <23:29>
+          InitExprNode <23:29> int
             ArrDesNode <23:64>
               IntConstExprNode <23:64> 2: int
             IdDesNode <23:67> square

--- a/test/typecheck/union.exp
+++ b/test/typecheck/union.exp
@@ -49,5 +49,8 @@ ProgramNode <1:1>
         VarDeclNode <25:15> a: union shape
         VarDeclNode <25:19> b: union shape*
         ArrDeclNode <25:22> c: union shape[3]
-      ReturnStmtNode <27:3>
-        IntConstExprNode <27:10> 0: int
+      ExprStmtNode <27:3>
+        RecordMemExprNode <27:3> .circle: int
+          IdExprNode <27:3> s: union shape
+      ReturnStmtNode <29:3>
+        IntConstExprNode <29:10> 0: int


### PR DESCRIPTION
### Changes for types

- Introduce a new struct `Field` for storing both id and `Type` for record members.
- Introduce a new class `RecordType` for sharing common methods for struct and union.

### AST

- Introduce a new AST node `RecordMemExprNode` for postfix record member access expression.

### Other

- Update dump info for `InitExprNode`.

P.S: I had added additional typecheck tests, but I haven't implemented any code generation for record declaration, so it will throw error `src/qbe_ir_generator.cpp:108: int {anonymous}::PrevExprNumRecorder::NumOfPrevExpr(): Assertion num_of_prev_expr_ != kNoRecord`. I can add additional expression tests after implementing code generation.

I can start implementing code generation for struct and union after this PR. 😄 