### PR TITLE
Remove redundant id check on function call

### DIFF
--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -121,12 +121,12 @@ void TypeChecker::Visit(FieldNode& field) {
   // NOTE: Do nothing since record_decl 'Clone' already copies every field.
 }
 
-void TypeChecker::Visit(RecordVarDeclNode& record_decl) {
-  if (env_.ProbeSymbol(record_decl.id)) {
+void TypeChecker::Visit(RecordVarDeclNode& record_var_decl) {
+  if (env_.ProbeSymbol(record_var_decl.id)) {
     // TODO: redefinition of 'id'
   } else {
-    // NOTE: record_decl doesn't know its own type, it needs to look up in the
-    // type table to update its type.
+    // NOTE: record_var_decl doesn't know its own type, it needs to look up in
+    // the type table to update its type.
     // struct birth { // RecordDeclNode -> stores type entry in type table
     //   int date;
     // };
@@ -135,15 +135,15 @@ void TypeChecker::Visit(RecordVarDeclNode& record_decl) {
     // to update its type.
     // record_type_id is "struct_birth" in the above example.
     auto record_type_id =
-        dynamic_cast<RecordType*>(record_decl.type.get())->id();
-    auto record_type =
-        env_.LookUpType(MangleRecordTypeId(record_type_id, record_decl.type));
+        dynamic_cast<RecordType*>(record_var_decl.type.get())->id();
+    auto record_type = env_.LookUpType(
+        MangleRecordTypeId(record_type_id, record_var_decl.type));
     assert(record_type);
-    auto symbol = std::make_unique<SymbolEntry>(record_decl.id,
+    auto symbol = std::make_unique<SymbolEntry>(record_var_decl.id,
                                                 record_type->type->Clone());
 
     // TODO: type check between fields and initialized members.
-    for (auto& init : record_decl.inits) {
+    for (auto& init : record_var_decl.inits) {
       init->Accept(*this);
     }
     // TODO: May be file scope once we support global variables.

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -459,14 +459,6 @@ void TypeChecker::Visit(FuncCallExprNode& call_expr) {
   if (call_expr.func_expr->type->IsFunc()) {
     func_type = std::dynamic_pointer_cast<FuncType>(
         std::shared_ptr<Type>{call_expr.func_expr->type->Clone()});
-    const auto* id_expr =
-        dynamic_cast<IdExprNode*>((call_expr.func_expr).get());
-    // If is an identifier, either a function or a function pointer, it should
-    // be declared.
-    if (id_expr && !env_.LookUpSymbol(id_expr->id)) {
-      // TODO: use of undeclared identifier 'id'
-      assert(false);
-    }
   } else if (const auto* ptr_type =
                  dynamic_cast<PtrType*>((call_expr.func_expr->type).get());
              ptr_type->base_type().IsFunc()) {


### PR DESCRIPTION
This PR addressed the redundant id check issue mentioned in #163, as whether the id is declared or not is already checked by the visit function of `IdExprNode`.

Additionally, I renamed a parameter that had confused me. We use abbreviations of AST node types for parameters in the visit function. However, the parameter for `RecordVarDeclNode` violates this convention, which caused confusion and made it seem like I was looking at the visit function for `RecordDeclNode`.
