### PR TITLE
Global variable declaration type check

### DIFF
--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -220,8 +220,8 @@ struct CompoundStmtNode : public StmtNode {
   std::vector<std::unique_ptr<StmtNode>> stmts;
 };
 
-/// @brief An external definition is an external declaration that is also a
-/// definition of a function(other than an inline definition) or an object.
+/// @brief An external declaration can be a definition of a function or an
+/// object.
 struct ExternDeclNode : public AstNode {
   ExternDeclNode(
       Location loc,
@@ -236,17 +236,18 @@ struct ExternDeclNode : public AstNode {
       decl;
 };
 
-/// @brief Root of the entire program.
-struct ProgramNode : public AstNode {
+/// @brief A translation unit, which the compiler handles individually,
+/// representing a high-level entity in the compilation process.
+struct TransUnitNode : public AstNode {
   /// @note vector of move-only elements are move-only
-  ProgramNode(Location loc,
-              std::vector<std::unique_ptr<ExternDeclNode>> trans_unit)
-      : AstNode{loc}, trans_unit{std::move(trans_unit)} {}
+  TransUnitNode(Location loc,
+                std::vector<std::unique_ptr<ExternDeclNode>> extern_decls)
+      : AstNode{loc}, extern_decls{std::move(extern_decls)} {}
 
   void Accept(NonModifyingVisitor&) const override;
   void Accept(ModifyingVisitor&) override;
 
-  std::vector<std::unique_ptr<ExternDeclNode>> trans_unit;
+  std::vector<std::unique_ptr<ExternDeclNode>> extern_decls;
 };
 
 struct IfStmtNode : public StmtNode {

--- a/include/ast.hpp
+++ b/include/ast.hpp
@@ -220,17 +220,33 @@ struct CompoundStmtNode : public StmtNode {
   std::vector<std::unique_ptr<StmtNode>> stmts;
 };
 
-/// @brief Root of the entire program.
-struct ProgramNode : public AstNode {
-  /// @note vector of move-only elements are move-only
-  ProgramNode(Location loc,
-              std::vector<std::unique_ptr<FuncDefNode>> func_def_list)
-      : AstNode{loc}, func_def_list{std::move(func_def_list)} {}
+/// @brief An external definition is an external declaration that is also a
+/// definition of a function(other than an inline definition) or an object.
+struct ExternDeclNode : public AstNode {
+  ExternDeclNode(
+      Location loc,
+      std::variant<std::unique_ptr<FuncDefNode>, std::unique_ptr<DeclStmtNode>>
+          decl)
+      : AstNode{loc}, decl{std::move(decl)} {}
 
   void Accept(NonModifyingVisitor&) const override;
   void Accept(ModifyingVisitor&) override;
 
-  std::vector<std::unique_ptr<FuncDefNode>> func_def_list;
+  std::variant<std::unique_ptr<FuncDefNode>, std::unique_ptr<DeclStmtNode>>
+      decl;
+};
+
+/// @brief Root of the entire program.
+struct ProgramNode : public AstNode {
+  /// @note vector of move-only elements are move-only
+  ProgramNode(Location loc,
+              std::vector<std::unique_ptr<ExternDeclNode>> trans_unit)
+      : AstNode{loc}, trans_unit{std::move(trans_unit)} {}
+
+  void Accept(NonModifyingVisitor&) const override;
+  void Accept(ModifyingVisitor&) override;
+
+  std::vector<std::unique_ptr<ExternDeclNode>> trans_unit;
 };
 
 struct IfStmtNode : public StmtNode {

--- a/include/ast_dumper.hpp
+++ b/include/ast_dumper.hpp
@@ -17,6 +17,7 @@ class AstDumper : public NonModifyingVisitor {
   void Visit(const ParamNode&) override;
   void Visit(const FuncDefNode&) override;
   void Visit(const CompoundStmtNode&) override;
+  void Visit(const ExternDeclNode&) override;
   void Visit(const ProgramNode&) override;
   void Visit(const IfStmtNode&) override;
   void Visit(const WhileStmtNode&) override;

--- a/include/ast_dumper.hpp
+++ b/include/ast_dumper.hpp
@@ -18,7 +18,7 @@ class AstDumper : public NonModifyingVisitor {
   void Visit(const FuncDefNode&) override;
   void Visit(const CompoundStmtNode&) override;
   void Visit(const ExternDeclNode&) override;
-  void Visit(const ProgramNode&) override;
+  void Visit(const TransUnitNode&) override;
   void Visit(const IfStmtNode&) override;
   void Visit(const WhileStmtNode&) override;
   void Visit(const ForStmtNode&) override;

--- a/include/qbe_ir_generator.hpp
+++ b/include/qbe_ir_generator.hpp
@@ -25,7 +25,7 @@ class QbeIrGenerator : public NonModifyingVisitor {
   void Visit(const FuncDefNode&) override;
   void Visit(const CompoundStmtNode&) override;
   void Visit(const ExternDeclNode&) override;
-  void Visit(const ProgramNode&) override;
+  void Visit(const TransUnitNode&) override;
   void Visit(const IfStmtNode&) override;
   void Visit(const WhileStmtNode&) override;
   void Visit(const ForStmtNode&) override;

--- a/include/qbe_ir_generator.hpp
+++ b/include/qbe_ir_generator.hpp
@@ -24,6 +24,7 @@ class QbeIrGenerator : public NonModifyingVisitor {
   void Visit(const ParamNode&) override;
   void Visit(const FuncDefNode&) override;
   void Visit(const CompoundStmtNode&) override;
+  void Visit(const ExternDeclNode&) override;
   void Visit(const ProgramNode&) override;
   void Visit(const IfStmtNode&) override;
   void Visit(const WhileStmtNode&) override;

--- a/include/scope.hpp
+++ b/include/scope.hpp
@@ -49,7 +49,7 @@ class ScopeStack {
   void PopScope();
   /// @return Current scope kind.
   /// @throws `NotInScopeError`
-  ScopeKind CurrentScope();
+  ScopeKind CurrentScopeKind();
 
   /// @brief Merges the current scope with the next pushed scope.
   /// @throws `NotInScopeError` if currently not in any scope.

--- a/include/scope.hpp
+++ b/include/scope.hpp
@@ -47,6 +47,9 @@ class ScopeStack {
   /// @brief Pops the top scope of the stack.
   /// @throws `NotInScopeError`
   void PopScope();
+  /// @return Current scope kind.
+  /// @throws `NotInScopeError`
+  ScopeKind CurrentScope();
 
   /// @brief Merges the current scope with the next pushed scope.
   /// @throws `NotInScopeError` if currently not in any scope.

--- a/include/type_checker.hpp
+++ b/include/type_checker.hpp
@@ -21,7 +21,7 @@ class TypeChecker : public ModifyingVisitor {
   void Visit(FuncDefNode&) override;
   void Visit(CompoundStmtNode&) override;
   void Visit(ExternDeclNode&) override;
-  void Visit(ProgramNode&) override;
+  void Visit(TransUnitNode&) override;
   void Visit(IfStmtNode&) override;
   void Visit(WhileStmtNode&) override;
   void Visit(ForStmtNode&) override;
@@ -52,7 +52,6 @@ class TypeChecker : public ModifyingVisitor {
 
  private:
   ScopeStack& env_;
-  bool has_main_func_{false};
 
   /// @brief Installs the built-in functions into the environment.
   void InstallBuiltins_(ScopeStack&);

--- a/include/type_checker.hpp
+++ b/include/type_checker.hpp
@@ -8,7 +8,7 @@
 /// @brief A modifying pass; resolves the type of expressions.
 class TypeChecker : public ModifyingVisitor {
  public:
-  TypeChecker(ScopeStack& env) : env_{env} {}
+  TypeChecker(ScopeStack& env) : env_{env}, has_main_func_{false} {}
 
   void Visit(DeclStmtNode&) override;
   void Visit(LoopInitNode&) override;
@@ -20,6 +20,7 @@ class TypeChecker : public ModifyingVisitor {
   void Visit(ParamNode&) override;
   void Visit(FuncDefNode&) override;
   void Visit(CompoundStmtNode&) override;
+  void Visit(ExternDeclNode&) override;
   void Visit(ProgramNode&) override;
   void Visit(IfStmtNode&) override;
   void Visit(WhileStmtNode&) override;
@@ -51,6 +52,7 @@ class TypeChecker : public ModifyingVisitor {
 
  private:
   ScopeStack& env_;
+  bool has_main_func_;
 
   /// @brief Installs the built-in functions into the environment.
   void InstallBuiltins_(ScopeStack&);

--- a/include/type_checker.hpp
+++ b/include/type_checker.hpp
@@ -8,7 +8,7 @@
 /// @brief A modifying pass; resolves the type of expressions.
 class TypeChecker : public ModifyingVisitor {
  public:
-  TypeChecker(ScopeStack& env) : env_{env}, has_main_func_{false} {}
+  TypeChecker(ScopeStack& env) : env_{env} {}
 
   void Visit(DeclStmtNode&) override;
   void Visit(LoopInitNode&) override;
@@ -52,7 +52,7 @@ class TypeChecker : public ModifyingVisitor {
 
  private:
   ScopeStack& env_;
-  bool has_main_func_;
+  bool has_main_func_{false};
 
   /// @brief Installs the built-in functions into the environment.
   void InstallBuiltins_(ScopeStack&);

--- a/include/visitor.hpp
+++ b/include/visitor.hpp
@@ -22,7 +22,7 @@ struct FuncDefNode;
 struct LoopInitNode;
 struct CompoundStmtNode;
 struct ExternDeclNode;
-struct ProgramNode;
+struct TransUnitNode;
 struct IfStmtNode;
 struct WhileStmtNode;
 struct ForStmtNode;
@@ -85,7 +85,7 @@ class Visitor {
   virtual void Visit(CondMut<LoopInitNode>&){};
   virtual void Visit(CondMut<CompoundStmtNode>&){};
   virtual void Visit(CondMut<ExternDeclNode>&){};
-  virtual void Visit(CondMut<ProgramNode>&){};
+  virtual void Visit(CondMut<TransUnitNode>&){};
   virtual void Visit(CondMut<IfStmtNode>&){};
   virtual void Visit(CondMut<WhileStmtNode>&){};
   virtual void Visit(CondMut<ForStmtNode>&){};

--- a/include/visitor.hpp
+++ b/include/visitor.hpp
@@ -21,6 +21,7 @@ struct ParamNode;
 struct FuncDefNode;
 struct LoopInitNode;
 struct CompoundStmtNode;
+struct ExternDeclNode;
 struct ProgramNode;
 struct IfStmtNode;
 struct WhileStmtNode;
@@ -83,6 +84,7 @@ class Visitor {
   virtual void Visit(CondMut<FuncDefNode>&){};
   virtual void Visit(CondMut<LoopInitNode>&){};
   virtual void Visit(CondMut<CompoundStmtNode>&){};
+  virtual void Visit(CondMut<ExternDeclNode>&){};
   virtual void Visit(CondMut<ProgramNode>&){};
   virtual void Visit(CondMut<IfStmtNode>&){};
   virtual void Visit(CondMut<WhileStmtNode>&){};

--- a/main.cpp
+++ b/main.cpp
@@ -69,8 +69,8 @@ int main(  // NOLINT(bugprone-exception-escape): Using a big try-catch block to
   }
 
   /// @brief The root node of the program.
-  auto program = std::unique_ptr<AstNode>{};
-  yy::parser parser{program};
+  auto trans_unit = std::unique_ptr<AstNode>{};
+  yy::parser parser{trans_unit};
   int ret = parser.parse();
 
   // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
@@ -85,19 +85,19 @@ int main(  // NOLINT(bugprone-exception-escape): Using a big try-catch block to
   // perform analyses and transformations on the ast
   auto scopes = ScopeStack{};
   TypeChecker type_checker{scopes};
-  program->Accept(type_checker);
+  trans_unit->Accept(type_checker);
   if (opts["dump"].as<bool>()) {
     const auto max_level = 80u;
     AstDumper ast_dumper{Indenter{' ', Indenter::SizePerLevel{2},
                                   Indenter::MaxLevel{max_level}}};
-    program->Accept(ast_dumper);
+    trans_unit->Accept(ast_dumper);
   }
 
   // generate intermediate representation
   auto input_basename = input_path.stem().string();
   auto output_ir = std::ofstream{fmt::format("{}.ssa", input_basename)};
   QbeIrGenerator code_generator{output_ir};
-  program->Accept(code_generator);
+  trans_unit->Accept(code_generator);
 
   output_ir.close();
 

--- a/parser.y
+++ b/parser.y
@@ -104,7 +104,6 @@ std::unique_ptr<Type> ResolveType(std::unique_ptr<Type> resolved_type,
 %nterm <std::unique_ptr<ExprNode>> and_expr eq_expr relational_expr shift_expr add_expr mul_expr cast_expr
 %nterm <std::unique_ptr<DeclNode>> id_opt
 %nterm <std::unique_ptr<DeclStmtNode>> decl
-%nterm <std::vector<std::unique_ptr<DeclStmtNode>>> decls decls_opt
 %nterm <std::unique_ptr<ParamNode>> parameter_declaration
 %nterm <std::vector<std::unique_ptr<ParamNode>>> parameter_type_list_opt parameter_type_list parameter_list
 %nterm <std::unique_ptr<FieldNode>> struct_declaration struct_declarator struct_declarator_list
@@ -161,7 +160,6 @@ entry: trans_unit {
   }
   ;
 
-// TODO: support global variables
 trans_unit: external_decl {
     $$ = std::vector<std::unique_ptr<ExternDeclNode>>{};
     $$.push_back($1);

--- a/parser.y
+++ b/parser.y
@@ -54,7 +54,7 @@ std::unique_ptr<Type> ResolveType(std::unique_ptr<Type> resolved_type,
 %language "c++"
 %locations
 
-%parse-param {std::unique_ptr<AstNode>& program}
+%parse-param {std::unique_ptr<AstNode>& trans_unit}
 
 // Use complete symbols (parser::symbol_type).
 %define api.token.constructor
@@ -156,7 +156,7 @@ std::unique_ptr<Type> ResolveType(std::unique_ptr<Type> resolved_type,
 
 %%
 entry: trans_unit {
-    program = std::make_unique<ProgramNode>(Loc(@1), $1);
+    trans_unit = std::make_unique<TransUnitNode>(Loc(@1), $1);
   }
   ;
 

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -140,6 +140,14 @@ void ProgramNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
+void ExternDeclNode::Accept(NonModifyingVisitor& v) const {
+  v.Visit(*this);
+}
+
+void ExternDeclNode::Accept(ModifyingVisitor& v) {
+  v.Visit(*this);
+}
+
 void IfStmtNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -132,11 +132,11 @@ void CompoundStmtNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 
-void ProgramNode::Accept(NonModifyingVisitor& v) const {
+void TransUnitNode::Accept(NonModifyingVisitor& v) const {
   v.Visit(*this);
 }
 
-void ProgramNode::Accept(ModifyingVisitor& v) {
+void TransUnitNode::Accept(ModifyingVisitor& v) {
   v.Visit(*this);
 }
 

--- a/src/ast_dumper.cpp
+++ b/src/ast_dumper.cpp
@@ -190,11 +190,20 @@ void AstDumper::Visit(const CompoundStmtNode& compound_stmt) {
   indenter_.DecreaseLevel();
 }
 
+void AstDumper::Visit(const ExternDeclNode& extern_decl) {
+  std::cout << indenter_.Indent() << "ExternDeclNode <" << extern_decl.loc
+            << ">\n";
+  indenter_.IncreaseLevel();
+  std::visit([this](auto&& extern_decl) { extern_decl->Accept(*this); },
+             extern_decl.decl);
+  indenter_.DecreaseLevel();
+}
+
 void AstDumper::Visit(const ProgramNode& program) {
   std::cout << indenter_.Indent() << "ProgramNode <" << program.loc << ">\n";
   indenter_.IncreaseLevel();
-  for (const auto& func_def : program.func_def_list) {
-    func_def->Accept(*this);
+  for (const auto& trans_unit : program.trans_unit) {
+    trans_unit->Accept(*this);
   }
   indenter_.DecreaseLevel();
 }

--- a/src/ast_dumper.cpp
+++ b/src/ast_dumper.cpp
@@ -199,11 +199,12 @@ void AstDumper::Visit(const ExternDeclNode& extern_decl) {
   indenter_.DecreaseLevel();
 }
 
-void AstDumper::Visit(const ProgramNode& program) {
-  std::cout << indenter_.Indent() << "ProgramNode <" << program.loc << ">\n";
+void AstDumper::Visit(const TransUnitNode& trans_unit) {
+  std::cout << indenter_.Indent() << "TransUnitNode <" << trans_unit.loc
+            << ">\n";
   indenter_.IncreaseLevel();
-  for (const auto& trans_unit : program.trans_unit) {
-    trans_unit->Accept(*this);
+  for (const auto& extern_decl : trans_unit.extern_decls) {
+    extern_decl->Accept(*this);
   }
   indenter_.DecreaseLevel();
 }

--- a/src/qbe_ir_generator.cpp
+++ b/src/qbe_ir_generator.cpp
@@ -316,12 +316,12 @@ void QbeIrGenerator::Visit(const ExternDeclNode& extern_decl) {
              extern_decl.decl);
 }
 
-void QbeIrGenerator::Visit(const ProgramNode& program) {
+void QbeIrGenerator::Visit(const TransUnitNode& trans_unit) {
   // Generate the data of builtin functions.
   Write_("data {} = align 1 {{ b \"%d\\012\\000\", }}\n",
          user_defined::GlobalPointer{"__builtin_print_format"});
 
-  for (const auto& extern_decl : program.trans_unit) {
+  for (const auto& extern_decl : trans_unit.extern_decls) {
     extern_decl->Accept(*this);
   }
 }

--- a/src/qbe_ir_generator.cpp
+++ b/src/qbe_ir_generator.cpp
@@ -309,13 +309,18 @@ void QbeIrGenerator::Visit(const CompoundStmtNode& compound_stmt) {
   }
 }
 
+void QbeIrGenerator::Visit(const ExternDeclNode& extern_decl) {
+  std::visit([this](auto&& extern_decl) { extern_decl->Accept(*this); },
+             extern_decl.decl);
+}
+
 void QbeIrGenerator::Visit(const ProgramNode& program) {
   // Generate the data of builtin functions.
   Write_("data {} = align 1 {{ b \"%d\\012\\000\", }}\n",
          user_defined::GlobalPointer{"__builtin_print_format"});
 
-  for (const auto& func_def : program.func_def_list) {
-    func_def->Accept(*this);
+  for (const auto& extern_decl : program.trans_unit) {
+    extern_decl->Accept(*this);
   }
 }
 

--- a/src/qbe_ir_generator.cpp
+++ b/src/qbe_ir_generator.cpp
@@ -136,6 +136,8 @@ auto
 }  // namespace
 
 void QbeIrGenerator::Visit(const DeclStmtNode& decl_stmt) {
+  // TODO: code generation for global variables, VarDeclNode, ArrDeclNode,
+  // RecordVarDeclNode
   for (const auto& decl : decl_stmt.decls) {
     decl->Accept(*this);
   }

--- a/src/scope.cpp
+++ b/src/scope.cpp
@@ -24,7 +24,7 @@ void ScopeStack::PopScope() {
   scopes_.pop_back();
 }
 
-ScopeKind ScopeStack::CurrentScope() {
+ScopeKind ScopeStack::CurrentScopeKind() {
   ThrowIfNotInScope_();
   return scopes_.back().kind;
 }

--- a/src/scope.cpp
+++ b/src/scope.cpp
@@ -24,6 +24,11 @@ void ScopeStack::PopScope() {
   scopes_.pop_back();
 }
 
+ScopeKind ScopeStack::CurrentScope() {
+  ThrowIfNotInScope_();
+  return scopes_.back().kind;
+}
+
 void ScopeStack::MergeWithNextScope() {
   ThrowIfNotInScope_();
   should_merge_with_next_scope_ = true;

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <iterator>
 #include <memory>
 #include <numeric>
 #include <stdexcept>

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -186,10 +186,6 @@ void TypeChecker::Visit(FuncDefNode& func_def) {
     // TODO: redefinition of function id
   }
 
-  if (func_def.id == "main") {
-    has_main_func_ = true;
-  }
-
   env_.PushScope(ScopeKind::kFunc);
   // NOTE: This block scope will be merged with the function body. Don't pop it.
   env_.PushScope(ScopeKind::kBlock);
@@ -255,17 +251,13 @@ void TypeChecker::Visit(ExternDeclNode& extern_decl) {
              extern_decl.decl);
 }
 
-void TypeChecker::Visit(ProgramNode& program) {
+void TypeChecker::Visit(TransUnitNode& trans_unit) {
   env_.PushScope(ScopeKind::kFile);
   InstallBuiltins_(env_);
-  for (auto& extern_decl : program.trans_unit) {
+  for (auto& extern_decl : trans_unit.extern_decls) {
     extern_decl->Accept(*this);
   }
 
-  if (!has_main_func_) {
-    // TODO: no main function
-    assert(false);
-  }
   env_.PopScope();
 }
 

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -73,7 +73,7 @@ void TypeChecker::Visit(VarDeclNode& decl) {
     // TODO: redefinition of 'id'
   } else {
     auto symbol = std::make_unique<SymbolEntry>(decl.id, decl.type->Clone());
-    env_.AddSymbol(std::move(symbol), env_.CurrentScope());
+    env_.AddSymbol(std::move(symbol), env_.CurrentScopeKind());
   }
 }
 
@@ -90,7 +90,7 @@ void TypeChecker::Visit(ArrDeclNode& arr_decl) {
         // TODO: element unmatches array element type
       }
     }
-    env_.AddSymbol(std::move(symbol), env_.CurrentScope());
+    env_.AddSymbol(std::move(symbol), env_.CurrentScopeKind());
   }
 
   // TODO: Check initializer type
@@ -110,8 +110,7 @@ void TypeChecker::Visit(RecordDeclNode& record_decl) {
     auto decl_type =
         std::make_unique<TypeEntry>(type_id, record_decl.type->Clone());
 
-    // TODO: May be file scope once we support global variables.
-    env_.AddType(std::move(decl_type), env_.CurrentScope());
+    env_.AddType(std::move(decl_type), env_.CurrentScopeKind());
   }
 }
 
@@ -144,7 +143,7 @@ void TypeChecker::Visit(RecordVarDeclNode& record_var_decl) {
     for (auto& init : record_var_decl.inits) {
       init->Accept(*this);
     }
-    env_.AddSymbol(std::move(symbol), env_.CurrentScope());
+    env_.AddSymbol(std::move(symbol), env_.CurrentScopeKind());
 
     record_var_decl.type = record_type->type->Clone();
   }

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -73,8 +73,7 @@ void TypeChecker::Visit(VarDeclNode& decl) {
     // TODO: redefinition of 'id'
   } else {
     auto symbol = std::make_unique<SymbolEntry>(decl.id, decl.type->Clone());
-    // TODO: May be file scope once we support global variables.
-    env_.AddSymbol(std::move(symbol), ScopeKind::kBlock);
+    env_.AddSymbol(std::move(symbol), env_.CurrentScope());
   }
 }
 
@@ -91,8 +90,7 @@ void TypeChecker::Visit(ArrDeclNode& arr_decl) {
         // TODO: element unmatches array element type
       }
     }
-    // TODO: May be file scope once we support global variables.
-    env_.AddSymbol(std::move(symbol), ScopeKind::kBlock);
+    env_.AddSymbol(std::move(symbol), env_.CurrentScope());
   }
 
   // TODO: Check initializer type
@@ -113,7 +111,7 @@ void TypeChecker::Visit(RecordDeclNode& record_decl) {
         std::make_unique<TypeEntry>(type_id, record_decl.type->Clone());
 
     // TODO: May be file scope once we support global variables.
-    env_.AddType(std::move(decl_type), ScopeKind::kBlock);
+    env_.AddType(std::move(decl_type), env_.CurrentScope());
   }
 }
 
@@ -146,8 +144,7 @@ void TypeChecker::Visit(RecordVarDeclNode& record_var_decl) {
     for (auto& init : record_var_decl.inits) {
       init->Accept(*this);
     }
-    // TODO: May be file scope once we support global variables.
-    env_.AddSymbol(std::move(symbol), ScopeKind::kBlock);
+    env_.AddSymbol(std::move(symbol), env_.CurrentScope());
 
     record_var_decl.type = record_type->type->Clone();
   }

--- a/src/type_checker.cpp
+++ b/src/type_checker.cpp
@@ -190,6 +190,10 @@ void TypeChecker::Visit(FuncDefNode& func_def) {
     // TODO: redefinition of function id
   }
 
+  if (func_def.id == "main") {
+    has_main_func_ = true;
+  }
+
   env_.PushScope(ScopeKind::kFunc);
   // NOTE: This block scope will be merged with the function body. Don't pop it.
   env_.PushScope(ScopeKind::kBlock);
@@ -250,19 +254,21 @@ void TypeChecker::InstallBuiltins_(ScopeStack& env) {
   env.AddSymbol(std::move(symbol), ScopeKind::kFile);
 }
 
+void TypeChecker::Visit(ExternDeclNode& extern_decl) {
+  std::visit([this](auto&& extern_decl) { extern_decl->Accept(*this); },
+             extern_decl.decl);
+}
+
 void TypeChecker::Visit(ProgramNode& program) {
   env_.PushScope(ScopeKind::kFile);
   InstallBuiltins_(env_);
-  bool has_main_func = false;
-  for (auto& func_def : program.func_def_list) {
-    if (func_def->id == "main") {
-      has_main_func = true;
-    }
-    func_def->Accept(*this);
+  for (auto& extern_decl : program.trans_unit) {
+    extern_decl->Accept(*this);
   }
 
-  if (!has_main_func) {
+  if (!has_main_func_) {
     // TODO: no main function
+    assert(false);
   }
   env_.PopScope();
 }

--- a/test/typecheck/array.exp
+++ b/test/typecheck/array.exp
@@ -1,43 +1,44 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        ArrDeclNode <2:7> a: int[3]
-      ExprStmtNode <4:3>
-        SimpleAssignmentExprNode <4:8> int
-          ArrSubExprNode <4:3> int
-            IdExprNode <4:3> a: int[3]
-            IntConstExprNode <4:5> 0: int
-          IntConstExprNode <4:10> 1: int
-      ExprStmtNode <5:3>
-        SimpleAssignmentExprNode <5:8> int
-          ArrSubExprNode <5:3> int
-            IdExprNode <5:3> a: int[3]
-            IntConstExprNode <5:5> 1: int
-          IntConstExprNode <5:10> 2: int
-      ExprStmtNode <6:3>
-        SimpleAssignmentExprNode <6:8> int
-          ArrSubExprNode <6:3> int
-            IdExprNode <6:3> a: int[3]
-            IntConstExprNode <6:5> 2: int
-          BinaryExprNode <6:15> int +
-            ArrSubExprNode <6:10> int
-              IdExprNode <6:10> a: int[3]
-              IntConstExprNode <6:12> 1: int
-            IntConstExprNode <6:17> 1: int
-      DeclStmtNode <8:3>
-        VarDeclNode <8:7> b: int
-          IntConstExprNode <8:11> 0: int
-        ArrDeclNode <8:14> c: int[4]
-          InitExprNode <8:22> int
-            IntConstExprNode <8:22> 1: int
-          InitExprNode <8:22> int
-            SimpleAssignmentExprNode <8:27> int
-              IdExprNode <8:25> b: int
-              IntConstExprNode <8:29> 2: int
-          InitExprNode <8:22> int
-            IntConstExprNode <8:32> 3: int
-          InitExprNode <8:22> int
-            IntConstExprNode <8:35> 4: int
-      ReturnStmtNode <10:3>
-        IntConstExprNode <10:10> 0: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          ArrDeclNode <2:7> a: int[3]
+        ExprStmtNode <4:3>
+          SimpleAssignmentExprNode <4:8> int
+            ArrSubExprNode <4:3> int
+              IdExprNode <4:3> a: int[3]
+              IntConstExprNode <4:5> 0: int
+            IntConstExprNode <4:10> 1: int
+        ExprStmtNode <5:3>
+          SimpleAssignmentExprNode <5:8> int
+            ArrSubExprNode <5:3> int
+              IdExprNode <5:3> a: int[3]
+              IntConstExprNode <5:5> 1: int
+            IntConstExprNode <5:10> 2: int
+        ExprStmtNode <6:3>
+          SimpleAssignmentExprNode <6:8> int
+            ArrSubExprNode <6:3> int
+              IdExprNode <6:3> a: int[3]
+              IntConstExprNode <6:5> 2: int
+            BinaryExprNode <6:15> int +
+              ArrSubExprNode <6:10> int
+                IdExprNode <6:10> a: int[3]
+                IntConstExprNode <6:12> 1: int
+              IntConstExprNode <6:17> 1: int
+        DeclStmtNode <8:3>
+          VarDeclNode <8:7> b: int
+            IntConstExprNode <8:11> 0: int
+          ArrDeclNode <8:14> c: int[4]
+            InitExprNode <8:22> int
+              IntConstExprNode <8:22> 1: int
+            InitExprNode <8:22> int
+              SimpleAssignmentExprNode <8:27> int
+                IdExprNode <8:25> b: int
+                IntConstExprNode <8:29> 2: int
+            InitExprNode <8:22> int
+              IntConstExprNode <8:32> 3: int
+            InitExprNode <8:22> int
+              IntConstExprNode <8:35> 4: int
+        ReturnStmtNode <10:3>
+          IntConstExprNode <10:10> 0: int

--- a/test/typecheck/array.exp
+++ b/test/typecheck/array.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/array_param.exp
+++ b/test/typecheck/array_param.exp
@@ -1,4 +1,4 @@
-ProgramNode <2:1>
+TransUnitNode <2:1>
   ExternDeclNode <2:1>
     FuncDefNode <2:5> func: int (int*)
       ParamNode <2:14> a: int*

--- a/test/typecheck/array_param.exp
+++ b/test/typecheck/array_param.exp
@@ -1,23 +1,25 @@
-ProgramNode <1:1>
-  FuncDefNode <2:5> func: int (int*)
-    ParamNode <2:14> a: int*
-    CompoundStmtNode <2:20>
-      ReturnStmtNode <4:3>
-        IntConstExprNode <4:10> 0: int
-  FuncDefNode <7:5> main: int ()
-    CompoundStmtNode <7:12>
-      DeclStmtNode <8:3>
-        ArrDeclNode <8:7> a: int[3]
-          InitExprNode <8:15> int
-            IntConstExprNode <8:15> 1: int
-          InitExprNode <8:15> int
-            IntConstExprNode <8:18> 2: int
-          InitExprNode <8:15> int
-            IntConstExprNode <8:21> 3: int
-      ExprStmtNode <9:3>
-        FuncCallExprNode <9:3> int
-          IdExprNode <9:3> func: int (int*)
-          ArgExprNode <9:8> int[3]
-            IdExprNode <9:8> a: int[3]
-      ReturnStmtNode <10:3>
-        IntConstExprNode <10:10> 0: int
+ProgramNode <2:1>
+  ExternDeclNode <2:1>
+    FuncDefNode <2:5> func: int (int*)
+      ParamNode <2:14> a: int*
+      CompoundStmtNode <2:20>
+        ReturnStmtNode <4:3>
+          IntConstExprNode <4:10> 0: int
+  ExternDeclNode <7:1>
+    FuncDefNode <7:5> main: int ()
+      CompoundStmtNode <7:12>
+        DeclStmtNode <8:3>
+          ArrDeclNode <8:7> a: int[3]
+            InitExprNode <8:15> int
+              IntConstExprNode <8:15> 1: int
+            InitExprNode <8:15> int
+              IntConstExprNode <8:18> 2: int
+            InitExprNode <8:15> int
+              IntConstExprNode <8:21> 3: int
+        ExprStmtNode <9:3>
+          FuncCallExprNode <9:3> int
+            IdExprNode <9:3> func: int (int*)
+            ArgExprNode <9:8> int[3]
+              IdExprNode <9:8> a: int[3]
+        ReturnStmtNode <10:3>
+          IntConstExprNode <10:10> 0: int

--- a/test/typecheck/assignment_expr.exp
+++ b/test/typecheck/assignment_expr.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/assignment_expr.exp
+++ b/test/typecheck/assignment_expr.exp
@@ -1,11 +1,12 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> a: int
-      ExprStmtNode <3:3>
-        SimpleAssignmentExprNode <3:5> int
-          IdExprNode <3:3> a: int
-          BinaryExprNode <3:9> int +
-            IntConstExprNode <3:7> 3: int
-            IntConstExprNode <3:11> 2: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> a: int
+        ExprStmtNode <3:3>
+          SimpleAssignmentExprNode <3:5> int
+            IdExprNode <3:3> a: int
+            BinaryExprNode <3:9> int +
+              IntConstExprNode <3:7> 3: int
+              IntConstExprNode <3:11> 2: int

--- a/test/typecheck/bin_expr.exp
+++ b/test/typecheck/bin_expr.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/bin_expr.exp
+++ b/test/typecheck/bin_expr.exp
@@ -1,69 +1,70 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      ExprStmtNode <2:3>
-        BinaryExprNode <2:5> int +
-          IntConstExprNode <2:3> 1: int
-          IntConstExprNode <2:7> 2: int
-      ExprStmtNode <3:3>
-        BinaryExprNode <3:5> int -
-          IntConstExprNode <3:3> 1: int
-          IntConstExprNode <3:7> 2: int
-      ExprStmtNode <4:3>
-        BinaryExprNode <4:5> int *
-          IntConstExprNode <4:3> 1: int
-          IntConstExprNode <4:7> 2: int
-      ExprStmtNode <5:3>
-        BinaryExprNode <5:5> int /
-          IntConstExprNode <5:3> 1: int
-          IntConstExprNode <5:7> 2: int
-      ExprStmtNode <6:3>
-        BinaryExprNode <6:5> int %
-          IntConstExprNode <6:3> 1: int
-          IntConstExprNode <6:7> 2: int
-      ExprStmtNode <7:3>
-        BinaryExprNode <7:21> int +
-          BinaryExprNode <7:13> int +
-            BinaryExprNode <7:5> int -
-              IntConstExprNode <7:3> 1: int
-              BinaryExprNode <7:9> int *
-                IntConstExprNode <7:7> 2: int
-                IntConstExprNode <7:11> 3: int
-            BinaryExprNode <7:17> int /
-              IntConstExprNode <7:15> 4: int
-              IntConstExprNode <7:19> 5: int
-          BinaryExprNode <7:25> int %
-            IntConstExprNode <7:23> 6: int
-            IntConstExprNode <7:27> 2: int
-      ExprStmtNode <8:3>
-        BinaryExprNode <8:5> int &
-          IntConstExprNode <8:3> 1: int
-          IntConstExprNode <8:7> 4: int
-      ExprStmtNode <9:3>
-        BinaryExprNode <9:5> int |
-          IntConstExprNode <9:3> 1: int
-          IntConstExprNode <9:7> 2: int
-      ExprStmtNode <10:3>
-        BinaryExprNode <10:5> int ^
-          IntConstExprNode <10:3> 1: int
-          IntConstExprNode <10:7> 3: int
-      ExprStmtNode <11:3>
-        BinaryExprNode <11:5> int <<
-          IntConstExprNode <11:3> 1: int
-          IntConstExprNode <11:8> 16: int
-      ExprStmtNode <12:3>
-        BinaryExprNode <12:9> int >>
-          IntConstExprNode <12:3> 65536: int
-          IntConstExprNode <12:12> 16: int
-      ExprStmtNode <13:3>
-        BinaryExprNode <13:5> int &&
-          IntConstExprNode <13:3> 1: int
-          IntConstExprNode <13:8> 1: int
-      ExprStmtNode <14:3>
-        BinaryExprNode <14:5> int ||
-          IntConstExprNode <14:3> 0: int
-          IntConstExprNode <14:8> 0: int
-      ExprStmtNode <15:3>
-        BinaryExprNode <15:4> int ,
-          IntConstExprNode <15:3> 1: int
-          IntConstExprNode <15:6> 2: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        ExprStmtNode <2:3>
+          BinaryExprNode <2:5> int +
+            IntConstExprNode <2:3> 1: int
+            IntConstExprNode <2:7> 2: int
+        ExprStmtNode <3:3>
+          BinaryExprNode <3:5> int -
+            IntConstExprNode <3:3> 1: int
+            IntConstExprNode <3:7> 2: int
+        ExprStmtNode <4:3>
+          BinaryExprNode <4:5> int *
+            IntConstExprNode <4:3> 1: int
+            IntConstExprNode <4:7> 2: int
+        ExprStmtNode <5:3>
+          BinaryExprNode <5:5> int /
+            IntConstExprNode <5:3> 1: int
+            IntConstExprNode <5:7> 2: int
+        ExprStmtNode <6:3>
+          BinaryExprNode <6:5> int %
+            IntConstExprNode <6:3> 1: int
+            IntConstExprNode <6:7> 2: int
+        ExprStmtNode <7:3>
+          BinaryExprNode <7:21> int +
+            BinaryExprNode <7:13> int +
+              BinaryExprNode <7:5> int -
+                IntConstExprNode <7:3> 1: int
+                BinaryExprNode <7:9> int *
+                  IntConstExprNode <7:7> 2: int
+                  IntConstExprNode <7:11> 3: int
+              BinaryExprNode <7:17> int /
+                IntConstExprNode <7:15> 4: int
+                IntConstExprNode <7:19> 5: int
+            BinaryExprNode <7:25> int %
+              IntConstExprNode <7:23> 6: int
+              IntConstExprNode <7:27> 2: int
+        ExprStmtNode <8:3>
+          BinaryExprNode <8:5> int &
+            IntConstExprNode <8:3> 1: int
+            IntConstExprNode <8:7> 4: int
+        ExprStmtNode <9:3>
+          BinaryExprNode <9:5> int |
+            IntConstExprNode <9:3> 1: int
+            IntConstExprNode <9:7> 2: int
+        ExprStmtNode <10:3>
+          BinaryExprNode <10:5> int ^
+            IntConstExprNode <10:3> 1: int
+            IntConstExprNode <10:7> 3: int
+        ExprStmtNode <11:3>
+          BinaryExprNode <11:5> int <<
+            IntConstExprNode <11:3> 1: int
+            IntConstExprNode <11:8> 16: int
+        ExprStmtNode <12:3>
+          BinaryExprNode <12:9> int >>
+            IntConstExprNode <12:3> 65536: int
+            IntConstExprNode <12:12> 16: int
+        ExprStmtNode <13:3>
+          BinaryExprNode <13:5> int &&
+            IntConstExprNode <13:3> 1: int
+            IntConstExprNode <13:8> 1: int
+        ExprStmtNode <14:3>
+          BinaryExprNode <14:5> int ||
+            IntConstExprNode <14:3> 0: int
+            IntConstExprNode <14:8> 0: int
+        ExprStmtNode <15:3>
+          BinaryExprNode <15:4> int ,
+            IntConstExprNode <15:3> 1: int
+            IntConstExprNode <15:6> 2: int

--- a/test/typecheck/break_stmt.exp
+++ b/test/typecheck/break_stmt.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/break_stmt.exp
+++ b/test/typecheck/break_stmt.exp
@@ -1,11 +1,12 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      ForStmtNode <2:3>
-        LoopInitNode <2:8>
-          NullStmtNode <2:8>
-        NullStmtNode <2:9>
-        NullStmtNode <2:10>
-        BreakStmtNode <3:5>
-      ReturnStmtNode <5:3>
-        IntConstExprNode <5:10> 0: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        ForStmtNode <2:3>
+          LoopInitNode <2:8>
+            NullStmtNode <2:8>
+          NullStmtNode <2:9>
+          NullStmtNode <2:10>
+          BreakStmtNode <3:5>
+        ReturnStmtNode <5:3>
+          IntConstExprNode <5:10> 0: int

--- a/test/typecheck/comma_expr.exp
+++ b/test/typecheck/comma_expr.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/comma_expr.exp
+++ b/test/typecheck/comma_expr.exp
@@ -1,18 +1,19 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> i: int
-      DeclStmtNode <3:3>
-        VarDeclNode <3:8> p: int*
-      ReturnStmtNode <5:3>
-        BinaryExprNode <5:24> int ,
-          BinaryExprNode <5:17> int ,
-            SimpleAssignmentExprNode <5:13> int*
-              IdExprNode <5:11> p: int*
-              UnaryExprNode <5:15> int* &
-                IdExprNode <5:16> i: int
-            SimpleAssignmentExprNode <5:21> int
-              IdExprNode <5:19> i: int
-              IntConstExprNode <5:23> 0: int
-          IntConstExprNode <5:26> 3: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> i: int
+        DeclStmtNode <3:3>
+          VarDeclNode <3:8> p: int*
+        ReturnStmtNode <5:3>
+          BinaryExprNode <5:24> int ,
+            BinaryExprNode <5:17> int ,
+              SimpleAssignmentExprNode <5:13> int*
+                IdExprNode <5:11> p: int*
+                UnaryExprNode <5:15> int* &
+                  IdExprNode <5:16> i: int
+              SimpleAssignmentExprNode <5:21> int
+                IdExprNode <5:19> i: int
+                IntConstExprNode <5:23> 0: int
+            IntConstExprNode <5:26> 3: int

--- a/test/typecheck/comment.exp
+++ b/test/typecheck/comment.exp
@@ -1,4 +1,4 @@
-ProgramNode <4:1>
+TransUnitNode <4:1>
   ExternDeclNode <4:1>
     FuncDefNode <4:5> main: int ()
       CompoundStmtNode <4:40>

--- a/test/typecheck/comment.exp
+++ b/test/typecheck/comment.exp
@@ -1,5 +1,6 @@
-ProgramNode <1:1>
-  FuncDefNode <4:5> main: int ()
-    CompoundStmtNode <4:40>
-      ReturnStmtNode <15:3>
-        IntConstExprNode <15:10> 0: int
+ProgramNode <4:1>
+  ExternDeclNode <4:1>
+    FuncDefNode <4:5> main: int ()
+      CompoundStmtNode <4:40>
+        ReturnStmtNode <15:3>
+          IntConstExprNode <15:10> 0: int

--- a/test/typecheck/comp_expr.exp
+++ b/test/typecheck/comp_expr.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/comp_expr.exp
+++ b/test/typecheck/comp_expr.exp
@@ -1,27 +1,28 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      ExprStmtNode <2:3>
-        BinaryExprNode <2:5> int >
-          IntConstExprNode <2:3> 1: int
-          IntConstExprNode <2:7> 2: int
-      ExprStmtNode <3:3>
-        BinaryExprNode <3:5> int <
-          IntConstExprNode <3:3> 1: int
-          IntConstExprNode <3:7> 2: int
-      ExprStmtNode <4:3>
-        BinaryExprNode <4:5> int >=
-          IntConstExprNode <4:3> 1: int
-          IntConstExprNode <4:8> 2: int
-      ExprStmtNode <5:3>
-        BinaryExprNode <5:5> int <=
-          IntConstExprNode <5:3> 1: int
-          IntConstExprNode <5:8> 2: int
-      ExprStmtNode <6:3>
-        BinaryExprNode <6:5> int ==
-          IntConstExprNode <6:3> 1: int
-          IntConstExprNode <6:8> 2: int
-      ExprStmtNode <7:3>
-        BinaryExprNode <7:5> int !=
-          IntConstExprNode <7:3> 1: int
-          IntConstExprNode <7:8> 2: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        ExprStmtNode <2:3>
+          BinaryExprNode <2:5> int >
+            IntConstExprNode <2:3> 1: int
+            IntConstExprNode <2:7> 2: int
+        ExprStmtNode <3:3>
+          BinaryExprNode <3:5> int <
+            IntConstExprNode <3:3> 1: int
+            IntConstExprNode <3:7> 2: int
+        ExprStmtNode <4:3>
+          BinaryExprNode <4:5> int >=
+            IntConstExprNode <4:3> 1: int
+            IntConstExprNode <4:8> 2: int
+        ExprStmtNode <5:3>
+          BinaryExprNode <5:5> int <=
+            IntConstExprNode <5:3> 1: int
+            IntConstExprNode <5:8> 2: int
+        ExprStmtNode <6:3>
+          BinaryExprNode <6:5> int ==
+            IntConstExprNode <6:3> 1: int
+            IntConstExprNode <6:8> 2: int
+        ExprStmtNode <7:3>
+          BinaryExprNode <7:5> int !=
+            IntConstExprNode <7:3> 1: int
+            IntConstExprNode <7:8> 2: int

--- a/test/typecheck/compound_stmt.exp
+++ b/test/typecheck/compound_stmt.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/compound_stmt.exp
+++ b/test/typecheck/compound_stmt.exp
@@ -1,19 +1,20 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> i: int
-          IntConstExprNode <2:11> 1: int
-      ExprStmtNode <3:3>
-        SimpleAssignmentExprNode <3:5> int
-          IdExprNode <3:3> i: int
-          BinaryExprNode <3:9> int +
-            IdExprNode <3:7> i: int
-            IntConstExprNode <3:11> 1: int
-      DeclStmtNode <4:3>
-        VarDeclNode <4:7> j: int
-          IntConstExprNode <4:11> 2: int
-      ReturnStmtNode <5:3>
-        BinaryExprNode <5:12> int +
-          IdExprNode <5:10> i: int
-          IdExprNode <5:14> j: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> i: int
+            IntConstExprNode <2:11> 1: int
+        ExprStmtNode <3:3>
+          SimpleAssignmentExprNode <3:5> int
+            IdExprNode <3:3> i: int
+            BinaryExprNode <3:9> int +
+              IdExprNode <3:7> i: int
+              IntConstExprNode <3:11> 1: int
+        DeclStmtNode <4:3>
+          VarDeclNode <4:7> j: int
+            IntConstExprNode <4:11> 2: int
+        ReturnStmtNode <5:3>
+          BinaryExprNode <5:12> int +
+            IdExprNode <5:10> i: int
+            IdExprNode <5:14> j: int

--- a/test/typecheck/cond_expr.exp
+++ b/test/typecheck/cond_expr.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/cond_expr.exp
+++ b/test/typecheck/cond_expr.exp
@@ -1,16 +1,17 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> a: int
-          IntConstExprNode <2:11> 4: int
-      DeclStmtNode <3:3>
-        VarDeclNode <3:7> b: int
-          CondExprNode <3:18> int
-            BinaryExprNode <3:13> int ==
-              IdExprNode <3:11> a: int
-              IntConstExprNode <3:16> 4: int
-            IntConstExprNode <3:20> 2: int
-            IntConstExprNode <3:24> 3: int
-      ReturnStmtNode <4:3>
-        IntConstExprNode <4:10> 0: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> a: int
+            IntConstExprNode <2:11> 4: int
+        DeclStmtNode <3:3>
+          VarDeclNode <3:7> b: int
+            CondExprNode <3:18> int
+              BinaryExprNode <3:13> int ==
+                IdExprNode <3:11> a: int
+                IntConstExprNode <3:16> 4: int
+              IntConstExprNode <3:20> 2: int
+              IntConstExprNode <3:24> 3: int
+        ReturnStmtNode <4:3>
+          IntConstExprNode <4:10> 0: int

--- a/test/typecheck/continue_stmt.exp
+++ b/test/typecheck/continue_stmt.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/continue_stmt.exp
+++ b/test/typecheck/continue_stmt.exp
@@ -1,28 +1,29 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> a: int
-          IntConstExprNode <2:11> 0: int
-      WhileStmtNode <3:3>
-        // Do
-        CompoundStmtNode <3:6>
-          IfStmtNode <4:5>
-            IntConstExprNode <4:9> 1: int
-            // Then
-            CompoundStmtNode <4:12>
-              ExprStmtNode <5:7>
-                SimpleAssignmentExprNode <5:9> int
-                  IdExprNode <5:7> a: int
-                  IntConstExprNode <5:11> 5: int
-              ContinueStmtNode <6:7>
-          ExprStmtNode <8:5>
-            SimpleAssignmentExprNode <8:7> int
-              IdExprNode <8:5> a: int
-              IntConstExprNode <8:9> 0: int
-        // While
-        BinaryExprNode <10:14> int <
-          IdExprNode <10:12> a: int
-          IntConstExprNode <10:16> 5: int
-      ReturnStmtNode <12:3>
-        IntConstExprNode <12:10> 0: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> a: int
+            IntConstExprNode <2:11> 0: int
+        WhileStmtNode <3:3>
+          // Do
+          CompoundStmtNode <3:6>
+            IfStmtNode <4:5>
+              IntConstExprNode <4:9> 1: int
+              // Then
+              CompoundStmtNode <4:12>
+                ExprStmtNode <5:7>
+                  SimpleAssignmentExprNode <5:9> int
+                    IdExprNode <5:7> a: int
+                    IntConstExprNode <5:11> 5: int
+                ContinueStmtNode <6:7>
+            ExprStmtNode <8:5>
+              SimpleAssignmentExprNode <8:7> int
+                IdExprNode <8:5> a: int
+                IntConstExprNode <8:9> 0: int
+          // While
+          BinaryExprNode <10:14> int <
+            IdExprNode <10:12> a: int
+            IntConstExprNode <10:16> 5: int
+        ReturnStmtNode <12:3>
+          IntConstExprNode <12:10> 0: int

--- a/test/typecheck/decl.exp
+++ b/test/typecheck/decl.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/decl.exp
+++ b/test/typecheck/decl.exp
@@ -1,17 +1,18 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> i: int
-          IntConstExprNode <2:11> 0: int
-      DeclStmtNode <3:3>
-        VarDeclNode <3:7> j: int
-      DeclStmtNode <4:3>
-        VarDeclNode <4:3> : int
-      DeclStmtNode <5:3>
-        VarDeclNode <5:7> a: int
-        VarDeclNode <5:10> b: int
-          IntConstExprNode <5:14> 1: int
-        VarDeclNode <5:17> c: int
-        VarDeclNode <5:20> d: int
-          IntConstExprNode <5:24> 0: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> i: int
+            IntConstExprNode <2:11> 0: int
+        DeclStmtNode <3:3>
+          VarDeclNode <3:7> j: int
+        DeclStmtNode <4:3>
+          VarDeclNode <4:3> : int
+        DeclStmtNode <5:3>
+          VarDeclNode <5:7> a: int
+          VarDeclNode <5:10> b: int
+            IntConstExprNode <5:14> 1: int
+          VarDeclNode <5:17> c: int
+          VarDeclNode <5:20> d: int
+            IntConstExprNode <5:24> 0: int

--- a/test/typecheck/do_while_single_stmt.exp
+++ b/test/typecheck/do_while_single_stmt.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/do_while_single_stmt.exp
+++ b/test/typecheck/do_while_single_stmt.exp
@@ -1,20 +1,21 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> i: int
-          IntConstExprNode <2:11> 5: int
-      WhileStmtNode <3:3>
-        // Do
-        ExprStmtNode <4:5>
-          SimpleAssignmentExprNode <4:7> int
-            IdExprNode <4:5> i: int
-            BinaryExprNode <4:11> int -
-              IdExprNode <4:9> i: int
-              IntConstExprNode <4:13> 1: int
-        // While
-        BinaryExprNode <5:12> int >
-          IdExprNode <5:10> i: int
-          IntConstExprNode <5:14> 0: int
-      ReturnStmtNode <7:3>
-        IdExprNode <7:10> i: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> i: int
+            IntConstExprNode <2:11> 5: int
+        WhileStmtNode <3:3>
+          // Do
+          ExprStmtNode <4:5>
+            SimpleAssignmentExprNode <4:7> int
+              IdExprNode <4:5> i: int
+              BinaryExprNode <4:11> int -
+                IdExprNode <4:9> i: int
+                IntConstExprNode <4:13> 1: int
+          // While
+          BinaryExprNode <5:12> int >
+            IdExprNode <5:10> i: int
+            IntConstExprNode <5:14> 0: int
+        ReturnStmtNode <7:3>
+          IdExprNode <7:10> i: int

--- a/test/typecheck/do_while_stmt.exp
+++ b/test/typecheck/do_while_stmt.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/do_while_stmt.exp
+++ b/test/typecheck/do_while_stmt.exp
@@ -1,21 +1,22 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> i: int
-          IntConstExprNode <2:11> 0: int
-      WhileStmtNode <3:3>
-        // Do
-        CompoundStmtNode <3:6>
-          ExprStmtNode <4:5>
-            SimpleAssignmentExprNode <4:7> int
-              IdExprNode <4:5> i: int
-              BinaryExprNode <4:11> int +
-                IdExprNode <4:9> i: int
-                IntConstExprNode <4:13> 1: int
-        // While
-        BinaryExprNode <5:14> int <
-          IdExprNode <5:12> i: int
-          IntConstExprNode <5:16> 5: int
-      ReturnStmtNode <7:3>
-        IntConstExprNode <7:10> 0: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> i: int
+            IntConstExprNode <2:11> 0: int
+        WhileStmtNode <3:3>
+          // Do
+          CompoundStmtNode <3:6>
+            ExprStmtNode <4:5>
+              SimpleAssignmentExprNode <4:7> int
+                IdExprNode <4:5> i: int
+                BinaryExprNode <4:11> int +
+                  IdExprNode <4:9> i: int
+                  IntConstExprNode <4:13> 1: int
+          // While
+          BinaryExprNode <5:14> int <
+            IdExprNode <5:12> i: int
+            IntConstExprNode <5:16> 5: int
+        ReturnStmtNode <7:3>
+          IntConstExprNode <7:10> 0: int

--- a/test/typecheck/for_infinite_loop.exp
+++ b/test/typecheck/for_infinite_loop.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/for_infinite_loop.exp
+++ b/test/typecheck/for_infinite_loop.exp
@@ -1,12 +1,13 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      ForStmtNode <2:3>
-        LoopInitNode <2:8>
-          NullStmtNode <2:8>
-        NullStmtNode <2:9>
-        NullStmtNode <2:10>
-        ExprStmtNode <2:11>
-          NullStmtNode <2:11>
-      ReturnStmtNode <5:3>
-        IntConstExprNode <5:10> 0: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        ForStmtNode <2:3>
+          LoopInitNode <2:8>
+            NullStmtNode <2:8>
+          NullStmtNode <2:9>
+          NullStmtNode <2:10>
+          ExprStmtNode <2:11>
+            NullStmtNode <2:11>
+        ReturnStmtNode <5:3>
+          IntConstExprNode <5:10> 0: int

--- a/test/typecheck/for_nested_stmt.exp
+++ b/test/typecheck/for_nested_stmt.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/for_nested_stmt.exp
+++ b/test/typecheck/for_nested_stmt.exp
@@ -1,42 +1,43 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> k: int
-          IntConstExprNode <2:11> 0: int
-      ForStmtNode <3:3>
-        LoopInitNode <3:8>
-          DeclStmtNode <3:8>
-            VarDeclNode <3:12> i: int
-              IntConstExprNode <3:16> 0: int
-        BinaryExprNode <3:21> int <
-          IdExprNode <3:19> i: int
-          IntConstExprNode <3:23> 5: int
-        SimpleAssignmentExprNode <3:28> int
-          IdExprNode <3:26> i: int
-          BinaryExprNode <3:32> int +
-            IdExprNode <3:30> i: int
-            IntConstExprNode <3:34> 1: int
-        CompoundStmtNode <3:37>
-          ForStmtNode <4:5>
-            LoopInitNode <4:10>
-              DeclStmtNode <4:10>
-                VarDeclNode <4:14> j: int
-                  IntConstExprNode <4:18> 0: int
-            BinaryExprNode <4:23> int <
-              IdExprNode <4:21> j: int
-              IntConstExprNode <4:25> 5: int
-            SimpleAssignmentExprNode <4:30> int
-              IdExprNode <4:28> j: int
-              BinaryExprNode <4:34> int +
-                IdExprNode <4:32> j: int
-                IntConstExprNode <4:36> 1: int
-            CompoundStmtNode <4:39>
-              ExprStmtNode <5:7>
-                SimpleAssignmentExprNode <5:9> int
-                  IdExprNode <5:7> k: int
-                  BinaryExprNode <5:13> int +
-                    IdExprNode <5:11> k: int
-                    IntConstExprNode <5:15> 1: int
-      ReturnStmtNode <9:3>
-        IntConstExprNode <9:10> 0: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> k: int
+            IntConstExprNode <2:11> 0: int
+        ForStmtNode <3:3>
+          LoopInitNode <3:8>
+            DeclStmtNode <3:8>
+              VarDeclNode <3:12> i: int
+                IntConstExprNode <3:16> 0: int
+          BinaryExprNode <3:21> int <
+            IdExprNode <3:19> i: int
+            IntConstExprNode <3:23> 5: int
+          SimpleAssignmentExprNode <3:28> int
+            IdExprNode <3:26> i: int
+            BinaryExprNode <3:32> int +
+              IdExprNode <3:30> i: int
+              IntConstExprNode <3:34> 1: int
+          CompoundStmtNode <3:37>
+            ForStmtNode <4:5>
+              LoopInitNode <4:10>
+                DeclStmtNode <4:10>
+                  VarDeclNode <4:14> j: int
+                    IntConstExprNode <4:18> 0: int
+              BinaryExprNode <4:23> int <
+                IdExprNode <4:21> j: int
+                IntConstExprNode <4:25> 5: int
+              SimpleAssignmentExprNode <4:30> int
+                IdExprNode <4:28> j: int
+                BinaryExprNode <4:34> int +
+                  IdExprNode <4:32> j: int
+                  IntConstExprNode <4:36> 1: int
+              CompoundStmtNode <4:39>
+                ExprStmtNode <5:7>
+                  SimpleAssignmentExprNode <5:9> int
+                    IdExprNode <5:7> k: int
+                    BinaryExprNode <5:13> int +
+                      IdExprNode <5:11> k: int
+                      IntConstExprNode <5:15> 1: int
+        ReturnStmtNode <9:3>
+          IntConstExprNode <9:10> 0: int

--- a/test/typecheck/for_stmt.exp
+++ b/test/typecheck/for_stmt.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/for_stmt.exp
+++ b/test/typecheck/for_stmt.exp
@@ -1,52 +1,53 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> j: int
-          IntConstExprNode <2:11> 0: int
-      DeclStmtNode <3:3>
-        VarDeclNode <3:7> i: int
-      ForStmtNode <4:3>
-        LoopInitNode <4:8>
-          SimpleAssignmentExprNode <4:10> int
-            IdExprNode <4:8> i: int
-            IntConstExprNode <4:12> 0: int
-        BinaryExprNode <4:28> int <
-          IdExprNode <4:26> i: int
-          IntConstExprNode <4:30> 5: int
-        SimpleAssignmentExprNode <4:35> int
-          IdExprNode <4:33> i: int
-          BinaryExprNode <4:39> int +
-            IdExprNode <4:37> i: int
-            IntConstExprNode <4:41> 1: int
-        CompoundStmtNode <4:44>
-          ExprStmtNode <5:5>
-            SimpleAssignmentExprNode <5:7> int
-              IdExprNode <5:5> j: int
-              BinaryExprNode <5:11> int +
-                IdExprNode <5:9> j: int
-                IntConstExprNode <5:13> 1: int
-      ForStmtNode <7:3>
-        LoopInitNode <7:8>
-          DeclStmtNode <7:8>
-            VarDeclNode <7:12> a: int
-              IntConstExprNode <7:16> 0: int
-            VarDeclNode <7:19> b: int
-              IntConstExprNode <7:23> 5: int
-        BinaryExprNode <7:39> int <
-          IdExprNode <7:37> a: int
-          IdExprNode <7:41> b: int
-        SimpleAssignmentExprNode <7:46> int
-          IdExprNode <7:44> a: int
-          BinaryExprNode <7:50> int +
-            IdExprNode <7:48> a: int
-            IntConstExprNode <7:52> 1: int
-        CompoundStmtNode <7:55>
-          ExprStmtNode <8:5>
-            SimpleAssignmentExprNode <8:7> int
-              IdExprNode <8:5> j: int
-              BinaryExprNode <8:11> int +
-                IdExprNode <8:9> j: int
-                IntConstExprNode <8:13> 1: int
-      ReturnStmtNode <11:3>
-        IntConstExprNode <11:10> 0: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> j: int
+            IntConstExprNode <2:11> 0: int
+        DeclStmtNode <3:3>
+          VarDeclNode <3:7> i: int
+        ForStmtNode <4:3>
+          LoopInitNode <4:8>
+            SimpleAssignmentExprNode <4:10> int
+              IdExprNode <4:8> i: int
+              IntConstExprNode <4:12> 0: int
+          BinaryExprNode <4:28> int <
+            IdExprNode <4:26> i: int
+            IntConstExprNode <4:30> 5: int
+          SimpleAssignmentExprNode <4:35> int
+            IdExprNode <4:33> i: int
+            BinaryExprNode <4:39> int +
+              IdExprNode <4:37> i: int
+              IntConstExprNode <4:41> 1: int
+          CompoundStmtNode <4:44>
+            ExprStmtNode <5:5>
+              SimpleAssignmentExprNode <5:7> int
+                IdExprNode <5:5> j: int
+                BinaryExprNode <5:11> int +
+                  IdExprNode <5:9> j: int
+                  IntConstExprNode <5:13> 1: int
+        ForStmtNode <7:3>
+          LoopInitNode <7:8>
+            DeclStmtNode <7:8>
+              VarDeclNode <7:12> a: int
+                IntConstExprNode <7:16> 0: int
+              VarDeclNode <7:19> b: int
+                IntConstExprNode <7:23> 5: int
+          BinaryExprNode <7:39> int <
+            IdExprNode <7:37> a: int
+            IdExprNode <7:41> b: int
+          SimpleAssignmentExprNode <7:46> int
+            IdExprNode <7:44> a: int
+            BinaryExprNode <7:50> int +
+              IdExprNode <7:48> a: int
+              IntConstExprNode <7:52> 1: int
+          CompoundStmtNode <7:55>
+            ExprStmtNode <8:5>
+              SimpleAssignmentExprNode <8:7> int
+                IdExprNode <8:5> j: int
+                BinaryExprNode <8:11> int +
+                  IdExprNode <8:9> j: int
+                  IntConstExprNode <8:13> 1: int
+        ReturnStmtNode <11:3>
+          IntConstExprNode <11:10> 0: int

--- a/test/typecheck/func_call.exp
+++ b/test/typecheck/func_call.exp
@@ -1,10 +1,12 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> five: int ()
-    CompoundStmtNode <1:12>
-      ReturnStmtNode <2:3>
-        IntConstExprNode <2:10> 5: int
-  FuncDefNode <5:5> main: int ()
-    CompoundStmtNode <5:12>
-      ReturnStmtNode <6:3>
-        FuncCallExprNode <6:10> int
-          IdExprNode <6:10> five: int ()
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> five: int ()
+      CompoundStmtNode <1:12>
+        ReturnStmtNode <2:3>
+          IntConstExprNode <2:10> 5: int
+  ExternDeclNode <5:1>
+    FuncDefNode <5:5> main: int ()
+      CompoundStmtNode <5:12>
+        ReturnStmtNode <6:3>
+          FuncCallExprNode <6:10> int
+            IdExprNode <6:10> five: int ()

--- a/test/typecheck/func_call.exp
+++ b/test/typecheck/func_call.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> five: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/func_call_param.exp
+++ b/test/typecheck/func_call_param.exp
@@ -1,41 +1,44 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> sum: int (int, int, int)
-    ParamNode <1:13> a: int
-    ParamNode <1:20> b: int
-    ParamNode <1:27> c: int
-    CompoundStmtNode <1:30>
-      ReturnStmtNode <2:3>
-        BinaryExprNode <2:16> int +
-          BinaryExprNode <2:12> int +
-            IdExprNode <2:10> a: int
-            IdExprNode <2:14> b: int
-          IdExprNode <2:18> c: int
-  FuncDefNode <5:5> add_five: int (int)
-    ParamNode <5:18> d: int
-    CompoundStmtNode <5:21>
-      ReturnStmtNode <6:3>
-        BinaryExprNode <6:12> int +
-          IdExprNode <6:10> d: int
-          IntConstExprNode <6:14> 5: int
-  FuncDefNode <9:5> main: int ()
-    CompoundStmtNode <9:12>
-      DeclStmtNode <10:3>
-        VarDeclNode <10:7> a: int
-          FuncCallExprNode <10:11> int
-            IdExprNode <10:11> sum: int (int, int, int)
-            ArgExprNode <10:15> int
-              IntConstExprNode <10:15> 1: int
-            ArgExprNode <10:18> int
-              IntConstExprNode <10:18> 2: int
-            ArgExprNode <10:21> int
-              IntConstExprNode <10:21> 3: int
-      DeclStmtNode <11:3>
-        VarDeclNode <11:7> b: int
-          BinaryExprNode <11:13> int +
-            IdExprNode <11:11> a: int
-            IntConstExprNode <11:15> 4: int
-      ReturnStmtNode <12:3>
-        FuncCallExprNode <12:10> int
-          IdExprNode <12:10> add_five: int (int)
-          ArgExprNode <12:19> int
-            IdExprNode <12:19> b: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> sum: int (int, int, int)
+      ParamNode <1:13> a: int
+      ParamNode <1:20> b: int
+      ParamNode <1:27> c: int
+      CompoundStmtNode <1:30>
+        ReturnStmtNode <2:3>
+          BinaryExprNode <2:16> int +
+            BinaryExprNode <2:12> int +
+              IdExprNode <2:10> a: int
+              IdExprNode <2:14> b: int
+            IdExprNode <2:18> c: int
+  ExternDeclNode <5:1>
+    FuncDefNode <5:5> add_five: int (int)
+      ParamNode <5:18> d: int
+      CompoundStmtNode <5:21>
+        ReturnStmtNode <6:3>
+          BinaryExprNode <6:12> int +
+            IdExprNode <6:10> d: int
+            IntConstExprNode <6:14> 5: int
+  ExternDeclNode <9:1>
+    FuncDefNode <9:5> main: int ()
+      CompoundStmtNode <9:12>
+        DeclStmtNode <10:3>
+          VarDeclNode <10:7> a: int
+            FuncCallExprNode <10:11> int
+              IdExprNode <10:11> sum: int (int, int, int)
+              ArgExprNode <10:15> int
+                IntConstExprNode <10:15> 1: int
+              ArgExprNode <10:18> int
+                IntConstExprNode <10:18> 2: int
+              ArgExprNode <10:21> int
+                IntConstExprNode <10:21> 3: int
+        DeclStmtNode <11:3>
+          VarDeclNode <11:7> b: int
+            BinaryExprNode <11:13> int +
+              IdExprNode <11:11> a: int
+              IntConstExprNode <11:15> 4: int
+        ReturnStmtNode <12:3>
+          FuncCallExprNode <12:10> int
+            IdExprNode <12:10> add_five: int (int)
+            ArgExprNode <12:19> int
+              IdExprNode <12:19> b: int

--- a/test/typecheck/func_call_param.exp
+++ b/test/typecheck/func_call_param.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> sum: int (int, int, int)
       ParamNode <1:13> a: int

--- a/test/typecheck/func_pointer.exp
+++ b/test/typecheck/func_pointer.exp
@@ -1,41 +1,43 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> add: int (int, int)
-    ParamNode <1:13> a: int
-    ParamNode <1:20> b: int
-    CompoundStmtNode <1:23>
-      ReturnStmtNode <2:3>
-        BinaryExprNode <2:12> int +
-          IdExprNode <2:10> a: int
-          IdExprNode <2:14> b: int
-  FuncDefNode <5:5> main: int ()
-    CompoundStmtNode <5:12>
-      DeclStmtNode <6:3>
-        VarDeclNode <6:9> p: int (*)(int, int)
-      ExprStmtNode <7:3>
-        SimpleAssignmentExprNode <7:5> int (*)(int, int)
-          IdExprNode <7:3> p: int (*)(int, int)
-          IdExprNode <7:7> add: int (int, int)
-      DeclStmtNode <8:3>
-        VarDeclNode <8:7> c: int
-          FuncCallExprNode <8:11> int
-            IdExprNode <8:11> p: int (*)(int, int)
-            ArgExprNode <8:13> int
-              IntConstExprNode <8:13> 2: int
-            ArgExprNode <8:16> int
-              IntConstExprNode <8:16> 3: int
-      ExprStmtNode <9:3>
-        SimpleAssignmentExprNode <9:5> int (*)(int, int)
-          IdExprNode <9:3> p: int (*)(int, int)
-          UnaryExprNode <9:7> int (*)(int, int) &
-            IdExprNode <9:8> add: int (int, int)
-      DeclStmtNode <10:3>
-        VarDeclNode <10:7> d: int
-          FuncCallExprNode <10:11> int
-            UnaryExprNode <10:12> int (int, int) *
-              IdExprNode <10:13> p: int (*)(int, int)
-            ArgExprNode <10:16> int
-              IntConstExprNode <10:16> 1: int
-            ArgExprNode <10:19> int
-              IntConstExprNode <10:19> 2: int
-      ReturnStmtNode <11:3>
-        IntConstExprNode <11:10> 0: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> add: int (int, int)
+      ParamNode <1:13> a: int
+      ParamNode <1:20> b: int
+      CompoundStmtNode <1:23>
+        ReturnStmtNode <2:3>
+          BinaryExprNode <2:12> int +
+            IdExprNode <2:10> a: int
+            IdExprNode <2:14> b: int
+  ExternDeclNode <5:1>
+    FuncDefNode <5:5> main: int ()
+      CompoundStmtNode <5:12>
+        DeclStmtNode <6:3>
+          VarDeclNode <6:9> p: int (*)(int, int)
+        ExprStmtNode <7:3>
+          SimpleAssignmentExprNode <7:5> int (*)(int, int)
+            IdExprNode <7:3> p: int (*)(int, int)
+            IdExprNode <7:7> add: int (int, int)
+        DeclStmtNode <8:3>
+          VarDeclNode <8:7> c: int
+            FuncCallExprNode <8:11> int
+              IdExprNode <8:11> p: int (*)(int, int)
+              ArgExprNode <8:13> int
+                IntConstExprNode <8:13> 2: int
+              ArgExprNode <8:16> int
+                IntConstExprNode <8:16> 3: int
+        ExprStmtNode <9:3>
+          SimpleAssignmentExprNode <9:5> int (*)(int, int)
+            IdExprNode <9:3> p: int (*)(int, int)
+            UnaryExprNode <9:7> int (*)(int, int) &
+              IdExprNode <9:8> add: int (int, int)
+        DeclStmtNode <10:3>
+          VarDeclNode <10:7> d: int
+            FuncCallExprNode <10:11> int
+              UnaryExprNode <10:12> int (int, int) *
+                IdExprNode <10:13> p: int (*)(int, int)
+              ArgExprNode <10:16> int
+                IntConstExprNode <10:16> 1: int
+              ArgExprNode <10:19> int
+                IntConstExprNode <10:19> 2: int
+        ReturnStmtNode <11:3>
+          IntConstExprNode <11:10> 0: int

--- a/test/typecheck/func_pointer.exp
+++ b/test/typecheck/func_pointer.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> add: int (int, int)
       ParamNode <1:13> a: int

--- a/test/typecheck/func_pointer_param.exp
+++ b/test/typecheck/func_pointer_param.exp
@@ -1,57 +1,61 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> add: int (int, int)
-    ParamNode <1:13> a: int
-    ParamNode <1:20> b: int
-    CompoundStmtNode <1:23>
-      ReturnStmtNode <2:3>
-        BinaryExprNode <2:12> int +
-          IdExprNode <2:10> a: int
-          IdExprNode <2:14> b: int
-  FuncDefNode <5:5> call: int (int (*)(int, int), int, int)
-    ParamNode <5:16> p: int (*)(int, int)
-    ParamNode <5:34> a: int
-    ParamNode <5:41> b: int
-    CompoundStmtNode <5:44>
-      ReturnStmtNode <6:3>
-        FuncCallExprNode <6:10> int
-          IdExprNode <6:10> p: int (*)(int, int)
-          ArgExprNode <6:12> int
-            IdExprNode <6:12> a: int
-          ArgExprNode <6:15> int
-            IdExprNode <6:15> b: int
-  FuncDefNode <10:5> call_decay: int (int (*)(int, int), int, int)
-    ParamNode <10:20> p: int (*)(int, int)
-    ParamNode <10:37> a: int
-    ParamNode <10:44> b: int
-    CompoundStmtNode <10:47>
-      ReturnStmtNode <12:3>
-        IntConstExprNode <12:10> 0: int
-  FuncDefNode <15:5> main: int ()
-    CompoundStmtNode <15:12>
-      DeclStmtNode <16:3>
-        VarDeclNode <16:9> c: int (*)(int (*)(int, int), int, int)
-          IdExprNode <16:43> call: int (int (*)(int, int), int, int)
-      ExprStmtNode <17:3>
-        FuncCallExprNode <17:3> int
-          IdExprNode <17:3> c: int (*)(int (*)(int, int), int, int)
-          ArgExprNode <17:5> int (int, int)
-            IdExprNode <17:5> add: int (int, int)
-          ArgExprNode <17:10> int
-            IntConstExprNode <17:10> 1: int
-          ArgExprNode <17:13> int
-            IntConstExprNode <17:13> 2: int
-      ExprStmtNode <18:3>
-        SimpleAssignmentExprNode <18:5> int (*)(int (*)(int, int), int, int)
-          IdExprNode <18:3> c: int (*)(int (*)(int, int), int, int)
-          IdExprNode <18:7> call_decay: int (int (*)(int, int), int, int)
-      ExprStmtNode <19:3>
-        FuncCallExprNode <19:3> int
-          IdExprNode <19:3> c: int (*)(int (*)(int, int), int, int)
-          ArgExprNode <19:5> int (int, int)
-            IdExprNode <19:5> add: int (int, int)
-          ArgExprNode <19:10> int
-            IntConstExprNode <19:10> 1: int
-          ArgExprNode <19:13> int
-            IntConstExprNode <19:13> 2: int
-      ReturnStmtNode <20:3>
-        IntConstExprNode <20:10> 0: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> add: int (int, int)
+      ParamNode <1:13> a: int
+      ParamNode <1:20> b: int
+      CompoundStmtNode <1:23>
+        ReturnStmtNode <2:3>
+          BinaryExprNode <2:12> int +
+            IdExprNode <2:10> a: int
+            IdExprNode <2:14> b: int
+  ExternDeclNode <5:1>
+    FuncDefNode <5:5> call: int (int (*)(int, int), int, int)
+      ParamNode <5:16> p: int (*)(int, int)
+      ParamNode <5:34> a: int
+      ParamNode <5:41> b: int
+      CompoundStmtNode <5:44>
+        ReturnStmtNode <6:3>
+          FuncCallExprNode <6:10> int
+            IdExprNode <6:10> p: int (*)(int, int)
+            ArgExprNode <6:12> int
+              IdExprNode <6:12> a: int
+            ArgExprNode <6:15> int
+              IdExprNode <6:15> b: int
+  ExternDeclNode <10:1>
+    FuncDefNode <10:5> call_decay: int (int (*)(int, int), int, int)
+      ParamNode <10:20> p: int (*)(int, int)
+      ParamNode <10:37> a: int
+      ParamNode <10:44> b: int
+      CompoundStmtNode <10:47>
+        ReturnStmtNode <12:3>
+          IntConstExprNode <12:10> 0: int
+  ExternDeclNode <15:1>
+    FuncDefNode <15:5> main: int ()
+      CompoundStmtNode <15:12>
+        DeclStmtNode <16:3>
+          VarDeclNode <16:9> c: int (*)(int (*)(int, int), int, int)
+            IdExprNode <16:43> call: int (int (*)(int, int), int, int)
+        ExprStmtNode <17:3>
+          FuncCallExprNode <17:3> int
+            IdExprNode <17:3> c: int (*)(int (*)(int, int), int, int)
+            ArgExprNode <17:5> int (int, int)
+              IdExprNode <17:5> add: int (int, int)
+            ArgExprNode <17:10> int
+              IntConstExprNode <17:10> 1: int
+            ArgExprNode <17:13> int
+              IntConstExprNode <17:13> 2: int
+        ExprStmtNode <18:3>
+          SimpleAssignmentExprNode <18:5> int (*)(int (*)(int, int), int, int)
+            IdExprNode <18:3> c: int (*)(int (*)(int, int), int, int)
+            IdExprNode <18:7> call_decay: int (int (*)(int, int), int, int)
+        ExprStmtNode <19:3>
+          FuncCallExprNode <19:3> int
+            IdExprNode <19:3> c: int (*)(int (*)(int, int), int, int)
+            ArgExprNode <19:5> int (int, int)
+              IdExprNode <19:5> add: int (int, int)
+            ArgExprNode <19:10> int
+              IntConstExprNode <19:10> 1: int
+            ArgExprNode <19:13> int
+              IntConstExprNode <19:13> 2: int
+        ReturnStmtNode <20:3>
+          IntConstExprNode <20:10> 0: int

--- a/test/typecheck/func_pointer_param.exp
+++ b/test/typecheck/func_pointer_param.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> add: int (int, int)
       ParamNode <1:13> a: int

--- a/test/typecheck/global_decl.c
+++ b/test/typecheck/global_decl.c
@@ -1,0 +1,5 @@
+// int c;
+
+int main() {
+  return 0;
+}

--- a/test/typecheck/global_decl.c
+++ b/test/typecheck/global_decl.c
@@ -1,5 +1,14 @@
-// int c;
+int c;
+int a[3] = {1, 2, 3};
+
+struct animal {
+  int lion;
+  int tiger;
+};
 
 int main() {
+  c;
+  a[0] = 2;
+  struct animal cat = { .lion = 1, .tiger = 1};
   return 0;
 }

--- a/test/typecheck/global_decl.exp
+++ b/test/typecheck/global_decl.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     DeclStmtNode <1:1>
       VarDeclNode <1:5> c: int

--- a/test/typecheck/global_decl.exp
+++ b/test/typecheck/global_decl.exp
@@ -1,6 +1,39 @@
-ProgramNode <3:1>
-  ExternDeclNode <3:1>
-    FuncDefNode <3:5> main: int ()
-      CompoundStmtNode <3:12>
-        ReturnStmtNode <4:3>
-          IntConstExprNode <4:10> 0: int
+ProgramNode <1:1>
+  ExternDeclNode <1:1>
+    DeclStmtNode <1:1>
+      VarDeclNode <1:5> c: int
+  ExternDeclNode <2:1>
+    DeclStmtNode <2:1>
+      ArrDeclNode <2:5> a: int[3]
+        InitExprNode <2:13> int
+          IntConstExprNode <2:13> 1: int
+        InitExprNode <2:13> int
+          IntConstExprNode <2:16> 2: int
+        InitExprNode <2:13> int
+          IntConstExprNode <2:19> 3: int
+  ExternDeclNode <4:1>
+    DeclStmtNode <4:1>
+      RecordDeclNode <4:8> struct animal definition
+        FieldNode <5:7> lion: int
+        FieldNode <6:7> tiger: int
+  ExternDeclNode <9:1>
+    FuncDefNode <9:5> main: int ()
+      CompoundStmtNode <9:12>
+        ExprStmtNode <10:3>
+          IdExprNode <10:3> c: int
+        ExprStmtNode <11:3>
+          SimpleAssignmentExprNode <11:8> int
+            ArrSubExprNode <11:3> int
+              IdExprNode <11:3> a: int[3]
+              IntConstExprNode <11:5> 0: int
+            IntConstExprNode <11:10> 2: int
+        DeclStmtNode <12:3>
+          RecordVarDeclNode <12:17> cat: struct animal
+            InitExprNode <12:25> int
+              IdDesNode <12:26> lion
+              IntConstExprNode <12:33> 1: int
+            InitExprNode <12:25> int
+              IdDesNode <12:37> tiger
+              IntConstExprNode <12:45> 1: int
+        ReturnStmtNode <13:3>
+          IntConstExprNode <13:10> 0: int

--- a/test/typecheck/global_decl.exp
+++ b/test/typecheck/global_decl.exp
@@ -1,0 +1,6 @@
+ProgramNode <3:1>
+  ExternDeclNode <3:1>
+    FuncDefNode <3:5> main: int ()
+      CompoundStmtNode <3:12>
+        ReturnStmtNode <4:3>
+          IntConstExprNode <4:10> 0: int

--- a/test/typecheck/goto_stmt.exp
+++ b/test/typecheck/goto_stmt.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/goto_stmt.exp
+++ b/test/typecheck/goto_stmt.exp
@@ -1,19 +1,20 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> i: int
-          IntConstExprNode <2:11> 0: int
-      CompoundStmtNode <3:3>
-        IdLabeledStmtNode <4:3> begin
-          ExprStmtNode <5:5>
-            SimpleAssignmentExprNode <5:7> int
-              IdExprNode <5:5> i: int
-              BinaryExprNode <5:11> int +
-                IdExprNode <5:9> i: int
-                IntConstExprNode <5:13> 1: int
-      GotoStmtNode <9:3> begin
-      DeclStmtNode <11:3>
-        VarDeclNode <11:7> begin: int
-      ReturnStmtNode <12:3>
-        IntConstExprNode <12:10> 0: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> i: int
+            IntConstExprNode <2:11> 0: int
+        CompoundStmtNode <3:3>
+          IdLabeledStmtNode <4:3> begin
+            ExprStmtNode <5:5>
+              SimpleAssignmentExprNode <5:7> int
+                IdExprNode <5:5> i: int
+                BinaryExprNode <5:11> int +
+                  IdExprNode <5:9> i: int
+                  IntConstExprNode <5:13> 1: int
+        GotoStmtNode <9:3> begin
+        DeclStmtNode <11:3>
+          VarDeclNode <11:7> begin: int
+        ReturnStmtNode <12:3>
+          IntConstExprNode <12:10> 0: int

--- a/test/typecheck/id_expr.exp
+++ b/test/typecheck/id_expr.exp
@@ -1,8 +1,9 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> i: int
-      DeclStmtNode <3:3>
-        VarDeclNode <3:7> j: int
-          IdExprNode <3:11> i: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> i: int
+        DeclStmtNode <3:3>
+          VarDeclNode <3:7> j: int
+            IdExprNode <3:11> i: int

--- a/test/typecheck/id_expr.exp
+++ b/test/typecheck/id_expr.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/identifier.exp
+++ b/test/typecheck/identifier.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/identifier.exp
+++ b/test/typecheck/identifier.exp
@@ -1,21 +1,22 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> _: int
-      DeclStmtNode <3:3>
-        VarDeclNode <3:7> __: int
-      DeclStmtNode <4:3>
-        VarDeclNode <4:7> i: int
-      DeclStmtNode <5:3>
-        VarDeclNode <5:7> _1: int
-      DeclStmtNode <6:3>
-        VarDeclNode <6:7> _i: int
-      DeclStmtNode <7:3>
-        VarDeclNode <7:7> _i1: int
-      DeclStmtNode <8:3>
-        VarDeclNode <8:7> _i1_: int
-      DeclStmtNode <9:3>
-        VarDeclNode <9:7> _I: int
-      DeclStmtNode <10:3>
-        VarDeclNode <10:7> _I1: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> _: int
+        DeclStmtNode <3:3>
+          VarDeclNode <3:7> __: int
+        DeclStmtNode <4:3>
+          VarDeclNode <4:7> i: int
+        DeclStmtNode <5:3>
+          VarDeclNode <5:7> _1: int
+        DeclStmtNode <6:3>
+          VarDeclNode <6:7> _i: int
+        DeclStmtNode <7:3>
+          VarDeclNode <7:7> _i1: int
+        DeclStmtNode <8:3>
+          VarDeclNode <8:7> _i1_: int
+        DeclStmtNode <9:3>
+          VarDeclNode <9:7> _I: int
+        DeclStmtNode <10:3>
+          VarDeclNode <10:7> _I1: int

--- a/test/typecheck/if_else_nested_single_stmt.exp
+++ b/test/typecheck/if_else_nested_single_stmt.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/if_else_nested_single_stmt.exp
+++ b/test/typecheck/if_else_nested_single_stmt.exp
@@ -1,32 +1,33 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> i: int
-          IntConstExprNode <2:11> 5: int
-      IfStmtNode <3:3>
-        BinaryExprNode <3:9> int <
-          IdExprNode <3:7> i: int
-          IntConstExprNode <3:11> 10: int
-        // Then
-        IfStmtNode <4:5>
-          BinaryExprNode <4:11> int <
-            IdExprNode <4:9> i: int
-            IntConstExprNode <4:13> 5: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> i: int
+            IntConstExprNode <2:11> 5: int
+        IfStmtNode <3:3>
+          BinaryExprNode <3:9> int <
+            IdExprNode <3:7> i: int
+            IntConstExprNode <3:11> 10: int
           // Then
-          ExprStmtNode <5:7>
-            SimpleAssignmentExprNode <5:9> int
-              IdExprNode <5:7> i: int
-              IntConstExprNode <5:11> 2: int
+          IfStmtNode <4:5>
+            BinaryExprNode <4:11> int <
+              IdExprNode <4:9> i: int
+              IntConstExprNode <4:13> 5: int
+            // Then
+            ExprStmtNode <5:7>
+              SimpleAssignmentExprNode <5:9> int
+                IdExprNode <5:7> i: int
+                IntConstExprNode <5:11> 2: int
+            // Else
+            ExprStmtNode <7:7>
+              SimpleAssignmentExprNode <7:9> int
+                IdExprNode <7:7> i: int
+                IntConstExprNode <7:11> 7: int
           // Else
-          ExprStmtNode <7:7>
-            SimpleAssignmentExprNode <7:9> int
-              IdExprNode <7:7> i: int
-              IntConstExprNode <7:11> 7: int
-        // Else
-        ExprStmtNode <9:5>
-          SimpleAssignmentExprNode <9:7> int
-            IdExprNode <9:5> i: int
-            IntConstExprNode <9:9> 15: int
-      ReturnStmtNode <11:3>
-        IdExprNode <11:10> i: int
+          ExprStmtNode <9:5>
+            SimpleAssignmentExprNode <9:7> int
+              IdExprNode <9:5> i: int
+              IntConstExprNode <9:9> 15: int
+        ReturnStmtNode <11:3>
+          IdExprNode <11:10> i: int

--- a/test/typecheck/if_else_nested_stmt.exp
+++ b/test/typecheck/if_else_nested_stmt.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/if_else_nested_stmt.exp
+++ b/test/typecheck/if_else_nested_stmt.exp
@@ -1,48 +1,49 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> i: int
-          IntConstExprNode <2:11> 25: int
-      IfStmtNode <3:3>
-        BinaryExprNode <3:9> int <
-          IdExprNode <3:7> i: int
-          IntConstExprNode <3:11> 10: int
-        // Then
-        CompoundStmtNode <3:15>
-          IfStmtNode <4:5>
-            BinaryExprNode <4:11> int <
-              IdExprNode <4:9> i: int
-              IntConstExprNode <4:13> 5: int
-            // Then
-            CompoundStmtNode <4:16>
-              ExprStmtNode <5:7>
-                SimpleAssignmentExprNode <5:9> int
-                  IdExprNode <5:7> i: int
-                  IntConstExprNode <5:11> 2: int
-            // Else
-            CompoundStmtNode <6:12>
-              ExprStmtNode <7:7>
-                SimpleAssignmentExprNode <7:9> int
-                  IdExprNode <7:7> i: int
-                  IntConstExprNode <7:11> 7: int
-        // Else
-        CompoundStmtNode <9:10>
-          IfStmtNode <10:5>
-            BinaryExprNode <10:11> int >
-              IdExprNode <10:9> i: int
-              IntConstExprNode <10:13> 20: int
-            // Then
-            CompoundStmtNode <10:17>
-              ExprStmtNode <11:7>
-                SimpleAssignmentExprNode <11:9> int
-                  IdExprNode <11:7> i: int
-                  IntConstExprNode <11:11> 30: int
-            // Else
-            CompoundStmtNode <12:12>
-              ExprStmtNode <13:7>
-                SimpleAssignmentExprNode <13:9> int
-                  IdExprNode <13:7> i: int
-                  IntConstExprNode <13:11> 15: int
-      ReturnStmtNode <17:3>
-        IdExprNode <17:10> i: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> i: int
+            IntConstExprNode <2:11> 25: int
+        IfStmtNode <3:3>
+          BinaryExprNode <3:9> int <
+            IdExprNode <3:7> i: int
+            IntConstExprNode <3:11> 10: int
+          // Then
+          CompoundStmtNode <3:15>
+            IfStmtNode <4:5>
+              BinaryExprNode <4:11> int <
+                IdExprNode <4:9> i: int
+                IntConstExprNode <4:13> 5: int
+              // Then
+              CompoundStmtNode <4:16>
+                ExprStmtNode <5:7>
+                  SimpleAssignmentExprNode <5:9> int
+                    IdExprNode <5:7> i: int
+                    IntConstExprNode <5:11> 2: int
+              // Else
+              CompoundStmtNode <6:12>
+                ExprStmtNode <7:7>
+                  SimpleAssignmentExprNode <7:9> int
+                    IdExprNode <7:7> i: int
+                    IntConstExprNode <7:11> 7: int
+          // Else
+          CompoundStmtNode <9:10>
+            IfStmtNode <10:5>
+              BinaryExprNode <10:11> int >
+                IdExprNode <10:9> i: int
+                IntConstExprNode <10:13> 20: int
+              // Then
+              CompoundStmtNode <10:17>
+                ExprStmtNode <11:7>
+                  SimpleAssignmentExprNode <11:9> int
+                    IdExprNode <11:7> i: int
+                    IntConstExprNode <11:11> 30: int
+              // Else
+              CompoundStmtNode <12:12>
+                ExprStmtNode <13:7>
+                  SimpleAssignmentExprNode <13:9> int
+                    IdExprNode <13:7> i: int
+                    IntConstExprNode <13:11> 15: int
+        ReturnStmtNode <17:3>
+          IdExprNode <17:10> i: int

--- a/test/typecheck/if_else_single_stmt.exp
+++ b/test/typecheck/if_else_single_stmt.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/if_else_single_stmt.exp
+++ b/test/typecheck/if_else_single_stmt.exp
@@ -1,26 +1,27 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> i: int
-          IntConstExprNode <2:11> 2: int
-      IfStmtNode <3:3>
-        BinaryExprNode <3:9> int >
-          IdExprNode <3:7> i: int
-          IntConstExprNode <3:11> 0: int
-        // Then
-        ExprStmtNode <4:5>
-          SimpleAssignmentExprNode <4:7> int
-            IdExprNode <4:5> i: int
-            BinaryExprNode <4:11> int -
-              IdExprNode <4:9> i: int
-              IntConstExprNode <4:13> 1: int
-        // Else
-        ExprStmtNode <6:5>
-          SimpleAssignmentExprNode <6:7> int
-            IdExprNode <6:5> i: int
-            BinaryExprNode <6:11> int +
-              IdExprNode <6:9> i: int
-              IntConstExprNode <6:13> 1: int
-      ReturnStmtNode <8:3>
-        IdExprNode <8:10> i: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> i: int
+            IntConstExprNode <2:11> 2: int
+        IfStmtNode <3:3>
+          BinaryExprNode <3:9> int >
+            IdExprNode <3:7> i: int
+            IntConstExprNode <3:11> 0: int
+          // Then
+          ExprStmtNode <4:5>
+            SimpleAssignmentExprNode <4:7> int
+              IdExprNode <4:5> i: int
+              BinaryExprNode <4:11> int -
+                IdExprNode <4:9> i: int
+                IntConstExprNode <4:13> 1: int
+          // Else
+          ExprStmtNode <6:5>
+            SimpleAssignmentExprNode <6:7> int
+              IdExprNode <6:5> i: int
+              BinaryExprNode <6:11> int +
+                IdExprNode <6:9> i: int
+                IntConstExprNode <6:13> 1: int
+        ReturnStmtNode <8:3>
+          IdExprNode <8:10> i: int

--- a/test/typecheck/if_else_stmt.exp
+++ b/test/typecheck/if_else_stmt.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/if_else_stmt.exp
+++ b/test/typecheck/if_else_stmt.exp
@@ -1,26 +1,27 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> i: int
-          IntConstExprNode <2:11> 2: int
-      IfStmtNode <3:3>
-        BinaryExprNode <3:9> int <
-          IdExprNode <3:7> i: int
-          IntConstExprNode <3:11> 0: int
-        // Then
-        CompoundStmtNode <3:14>
-          ExprStmtNode <4:5>
-            SimpleAssignmentExprNode <4:7> int
-              IdExprNode <4:5> i: int
-              IntConstExprNode <4:9> 0: int
-        // Else
-        CompoundStmtNode <5:10>
-          ExprStmtNode <6:5>
-            SimpleAssignmentExprNode <6:7> int
-              IdExprNode <6:5> i: int
-              BinaryExprNode <6:11> int +
-                IdExprNode <6:9> i: int
-                IntConstExprNode <6:13> 1: int
-      ReturnStmtNode <9:3>
-        IdExprNode <9:10> i: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> i: int
+            IntConstExprNode <2:11> 2: int
+        IfStmtNode <3:3>
+          BinaryExprNode <3:9> int <
+            IdExprNode <3:7> i: int
+            IntConstExprNode <3:11> 0: int
+          // Then
+          CompoundStmtNode <3:14>
+            ExprStmtNode <4:5>
+              SimpleAssignmentExprNode <4:7> int
+                IdExprNode <4:5> i: int
+                IntConstExprNode <4:9> 0: int
+          // Else
+          CompoundStmtNode <5:10>
+            ExprStmtNode <6:5>
+              SimpleAssignmentExprNode <6:7> int
+                IdExprNode <6:5> i: int
+                BinaryExprNode <6:11> int +
+                  IdExprNode <6:9> i: int
+                  IntConstExprNode <6:13> 1: int
+        ReturnStmtNode <9:3>
+          IdExprNode <9:10> i: int

--- a/test/typecheck/if_single_stmt.exp
+++ b/test/typecheck/if_single_stmt.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/if_single_stmt.exp
+++ b/test/typecheck/if_single_stmt.exp
@@ -1,19 +1,20 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> i: int
-          IntConstExprNode <2:11> 2: int
-      IfStmtNode <3:3>
-        BinaryExprNode <3:9> int >
-          IdExprNode <3:7> i: int
-          IntConstExprNode <3:11> 0: int
-        // Then
-        ExprStmtNode <4:5>
-          SimpleAssignmentExprNode <4:7> int
-            IdExprNode <4:5> i: int
-            BinaryExprNode <4:11> int +
-              IdExprNode <4:9> i: int
-              IntConstExprNode <4:13> 1: int
-      ReturnStmtNode <6:3>
-        IntConstExprNode <6:10> 0: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> i: int
+            IntConstExprNode <2:11> 2: int
+        IfStmtNode <3:3>
+          BinaryExprNode <3:9> int >
+            IdExprNode <3:7> i: int
+            IntConstExprNode <3:11> 0: int
+          // Then
+          ExprStmtNode <4:5>
+            SimpleAssignmentExprNode <4:7> int
+              IdExprNode <4:5> i: int
+              BinaryExprNode <4:11> int +
+                IdExprNode <4:9> i: int
+                IntConstExprNode <4:13> 1: int
+        ReturnStmtNode <6:3>
+          IntConstExprNode <6:10> 0: int

--- a/test/typecheck/if_stmt.exp
+++ b/test/typecheck/if_stmt.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/if_stmt.exp
+++ b/test/typecheck/if_stmt.exp
@@ -1,16 +1,17 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> i: int
-          IntConstExprNode <2:11> 2: int
-      IfStmtNode <3:3>
-        BinaryExprNode <3:9> int >
-          IdExprNode <3:7> i: int
-          IntConstExprNode <3:11> 0: int
-        // Then
-        CompoundStmtNode <3:14>
-          ReturnStmtNode <4:5>
-            IdExprNode <4:12> i: int
-      ReturnStmtNode <7:3>
-        IntConstExprNode <7:10> 0: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> i: int
+            IntConstExprNode <2:11> 2: int
+        IfStmtNode <3:3>
+          BinaryExprNode <3:9> int >
+            IdExprNode <3:7> i: int
+            IntConstExprNode <3:11> 0: int
+          // Then
+          CompoundStmtNode <3:14>
+            ReturnStmtNode <4:5>
+              IdExprNode <4:12> i: int
+        ReturnStmtNode <7:3>
+          IntConstExprNode <7:10> 0: int

--- a/test/typecheck/int_const_expr.exp
+++ b/test/typecheck/int_const_expr.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/int_const_expr.exp
+++ b/test/typecheck/int_const_expr.exp
@@ -1,5 +1,6 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      ExprStmtNode <2:3>
-        IntConstExprNode <2:3> 1: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        ExprStmtNode <2:3>
+          IntConstExprNode <2:3> 1: int

--- a/test/typecheck/null_stmt.exp
+++ b/test/typecheck/null_stmt.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/null_stmt.exp
+++ b/test/typecheck/null_stmt.exp
@@ -1,5 +1,6 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      ExprStmtNode <1:13>
-        NullStmtNode <1:13>
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        ExprStmtNode <1:13>
+          NullStmtNode <1:13>

--- a/test/typecheck/paren_expr.exp
+++ b/test/typecheck/paren_expr.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/paren_expr.exp
+++ b/test/typecheck/paren_expr.exp
@@ -1,19 +1,20 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      ExprStmtNode <2:3>
-        BinaryExprNode <2:5> int *
-          IntConstExprNode <2:3> 4: int
-          BinaryExprNode <2:10> int -
-            IntConstExprNode <2:8> 5: int
-            IntConstExprNode <2:12> 2: int
-      ExprStmtNode <3:3>
-        BinaryExprNode <3:6> int /
-          IntConstExprNode <3:3> 10: int
-          BinaryExprNode <3:17> int *
-            BinaryExprNode <3:12> int +
-              IntConstExprNode <3:10> 5: int
-              IntConstExprNode <3:14> 1: int
-            IntConstExprNode <3:19> 3: int
-      ReturnStmtNode <5:3>
-        IntConstExprNode <5:10> 0: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        ExprStmtNode <2:3>
+          BinaryExprNode <2:5> int *
+            IntConstExprNode <2:3> 4: int
+            BinaryExprNode <2:10> int -
+              IntConstExprNode <2:8> 5: int
+              IntConstExprNode <2:12> 2: int
+        ExprStmtNode <3:3>
+          BinaryExprNode <3:6> int /
+            IntConstExprNode <3:3> 10: int
+            BinaryExprNode <3:17> int *
+              BinaryExprNode <3:12> int +
+                IntConstExprNode <3:10> 5: int
+                IntConstExprNode <3:14> 1: int
+              IntConstExprNode <3:19> 3: int
+        ReturnStmtNode <5:3>
+          IntConstExprNode <5:10> 0: int

--- a/test/typecheck/pointer.exp
+++ b/test/typecheck/pointer.exp
@@ -1,30 +1,31 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> a: int
-          IntConstExprNode <2:11> 10: int
-      DeclStmtNode <3:3>
-        VarDeclNode <3:8> b: int*
-      DeclStmtNode <4:3>
-        VarDeclNode <4:8> c: int*
-          UnaryExprNode <4:12> int* &
-            IdExprNode <4:13> a: int
-      ExprStmtNode <5:3>
-        SimpleAssignmentExprNode <5:5> int*
-          IdExprNode <5:3> b: int*
-          IdExprNode <5:7> c: int*
-      ExprStmtNode <6:3>
-        SimpleAssignmentExprNode <6:6> int
-          UnaryExprNode <6:3> int *
-            IdExprNode <6:4> c: int*
-          IntConstExprNode <6:8> 5: int
-      DeclStmtNode <8:3>
-        VarDeclNode <8:8> x: int*
-        VarDeclNode <8:11> y: int
-        VarDeclNode <8:15> z: int*
-          UnaryExprNode <8:19> int** &
-            IdExprNode <8:20> c: int*
-      ReturnStmtNode <10:3>
-        UnaryExprNode <10:10> int *
-          IdExprNode <10:11> c: int*
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> a: int
+            IntConstExprNode <2:11> 10: int
+        DeclStmtNode <3:3>
+          VarDeclNode <3:8> b: int*
+        DeclStmtNode <4:3>
+          VarDeclNode <4:8> c: int*
+            UnaryExprNode <4:12> int* &
+              IdExprNode <4:13> a: int
+        ExprStmtNode <5:3>
+          SimpleAssignmentExprNode <5:5> int*
+            IdExprNode <5:3> b: int*
+            IdExprNode <5:7> c: int*
+        ExprStmtNode <6:3>
+          SimpleAssignmentExprNode <6:6> int
+            UnaryExprNode <6:3> int *
+              IdExprNode <6:4> c: int*
+            IntConstExprNode <6:8> 5: int
+        DeclStmtNode <8:3>
+          VarDeclNode <8:8> x: int*
+          VarDeclNode <8:11> y: int
+          VarDeclNode <8:15> z: int*
+            UnaryExprNode <8:19> int** &
+              IdExprNode <8:20> c: int*
+        ReturnStmtNode <10:3>
+          UnaryExprNode <10:10> int *
+            IdExprNode <10:11> c: int*

--- a/test/typecheck/pointer.exp
+++ b/test/typecheck/pointer.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/pointer_param.exp
+++ b/test/typecheck/pointer_param.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> add: int (int*, int*)
       ParamNode <1:14> x: int*

--- a/test/typecheck/pointer_param.exp
+++ b/test/typecheck/pointer_param.exp
@@ -1,31 +1,33 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> add: int (int*, int*)
-    ParamNode <1:14> x: int*
-    ParamNode <1:22> y: int*
-    CompoundStmtNode <1:25>
-      ReturnStmtNode <2:3>
-        BinaryExprNode <2:13> int +
-          UnaryExprNode <2:10> int *
-            IdExprNode <2:11> x: int*
-          UnaryExprNode <2:15> int *
-            IdExprNode <2:16> y: int*
-  FuncDefNode <5:5> main: int ()
-    CompoundStmtNode <5:12>
-      DeclStmtNode <6:3>
-        VarDeclNode <6:7> a: int
-          IntConstExprNode <6:11> 3: int
-      DeclStmtNode <7:3>
-        VarDeclNode <7:7> b: int
-          IntConstExprNode <7:11> 5: int
-      DeclStmtNode <8:3>
-        VarDeclNode <8:8> c: int*
-          UnaryExprNode <8:12> int* &
-            IdExprNode <8:13> b: int
-      ReturnStmtNode <9:3>
-        FuncCallExprNode <9:10> int
-          IdExprNode <9:10> add: int (int*, int*)
-          ArgExprNode <9:14> int*
-            UnaryExprNode <9:14> int* &
-              IdExprNode <9:15> a: int
-          ArgExprNode <9:18> int*
-            IdExprNode <9:18> c: int*
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> add: int (int*, int*)
+      ParamNode <1:14> x: int*
+      ParamNode <1:22> y: int*
+      CompoundStmtNode <1:25>
+        ReturnStmtNode <2:3>
+          BinaryExprNode <2:13> int +
+            UnaryExprNode <2:10> int *
+              IdExprNode <2:11> x: int*
+            UnaryExprNode <2:15> int *
+              IdExprNode <2:16> y: int*
+  ExternDeclNode <5:1>
+    FuncDefNode <5:5> main: int ()
+      CompoundStmtNode <5:12>
+        DeclStmtNode <6:3>
+          VarDeclNode <6:7> a: int
+            IntConstExprNode <6:11> 3: int
+        DeclStmtNode <7:3>
+          VarDeclNode <7:7> b: int
+            IntConstExprNode <7:11> 5: int
+        DeclStmtNode <8:3>
+          VarDeclNode <8:8> c: int*
+            UnaryExprNode <8:12> int* &
+              IdExprNode <8:13> b: int
+        ReturnStmtNode <9:3>
+          FuncCallExprNode <9:10> int
+            IdExprNode <9:10> add: int (int*, int*)
+            ArgExprNode <9:14> int*
+              UnaryExprNode <9:14> int* &
+                IdExprNode <9:15> a: int
+            ArgExprNode <9:18> int*
+              IdExprNode <9:18> c: int*

--- a/test/typecheck/pointer_to_pointer.exp
+++ b/test/typecheck/pointer_to_pointer.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/pointer_to_pointer.exp
+++ b/test/typecheck/pointer_to_pointer.exp
@@ -1,53 +1,54 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> a: int
-          IntConstExprNode <2:11> 10: int
-      DeclStmtNode <3:3>
-        VarDeclNode <3:8> pa: int*
-          UnaryExprNode <3:13> int* &
-            IdExprNode <3:14> a: int
-      DeclStmtNode <4:3>
-        VarDeclNode <4:9> ppa: int**
-          UnaryExprNode <4:15> int** &
-            IdExprNode <4:16> pa: int*
-      ExprStmtNode <5:3>
-        FuncCallExprNode <5:3> int
-          IdExprNode <5:3> __builtin_print: int (int)
-          ArgExprNode <5:19> int
-            UnaryExprNode <5:19> int *
-              UnaryExprNode <5:20> int* *
-                IdExprNode <5:21> ppa: int**
-      DeclStmtNode <7:3>
-        VarDeclNode <7:7> b: int
-          IntConstExprNode <7:11> 20: int
-      DeclStmtNode <8:3>
-        VarDeclNode <8:8> pb: int*
-          UnaryExprNode <8:13> int* &
-            IdExprNode <8:14> b: int
-      ExprStmtNode <9:3>
-        SimpleAssignmentExprNode <9:8> int*
-          UnaryExprNode <9:3> int* *
-            IdExprNode <9:4> ppa: int**
-          IdExprNode <9:10> pb: int*
-      ExprStmtNode <10:3>
-        FuncCallExprNode <10:3> int
-          IdExprNode <10:3> __builtin_print: int (int)
-          ArgExprNode <10:19> int
-            UnaryExprNode <10:19> int *
-              UnaryExprNode <10:20> int* *
-                IdExprNode <10:21> ppa: int**
-      ExprStmtNode <12:3>
-        SimpleAssignmentExprNode <12:9> int
-          UnaryExprNode <12:3> int *
-            UnaryExprNode <12:4> int* *
-              IdExprNode <12:5> ppa: int**
-          IntConstExprNode <12:11> 30: int
-      ExprStmtNode <13:3>
-        FuncCallExprNode <13:3> int
-          IdExprNode <13:3> __builtin_print: int (int)
-          ArgExprNode <13:19> int
-            IdExprNode <13:19> b: int
-      ReturnStmtNode <15:3>
-        IntConstExprNode <15:10> 0: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> a: int
+            IntConstExprNode <2:11> 10: int
+        DeclStmtNode <3:3>
+          VarDeclNode <3:8> pa: int*
+            UnaryExprNode <3:13> int* &
+              IdExprNode <3:14> a: int
+        DeclStmtNode <4:3>
+          VarDeclNode <4:9> ppa: int**
+            UnaryExprNode <4:15> int** &
+              IdExprNode <4:16> pa: int*
+        ExprStmtNode <5:3>
+          FuncCallExprNode <5:3> int
+            IdExprNode <5:3> __builtin_print: int (int)
+            ArgExprNode <5:19> int
+              UnaryExprNode <5:19> int *
+                UnaryExprNode <5:20> int* *
+                  IdExprNode <5:21> ppa: int**
+        DeclStmtNode <7:3>
+          VarDeclNode <7:7> b: int
+            IntConstExprNode <7:11> 20: int
+        DeclStmtNode <8:3>
+          VarDeclNode <8:8> pb: int*
+            UnaryExprNode <8:13> int* &
+              IdExprNode <8:14> b: int
+        ExprStmtNode <9:3>
+          SimpleAssignmentExprNode <9:8> int*
+            UnaryExprNode <9:3> int* *
+              IdExprNode <9:4> ppa: int**
+            IdExprNode <9:10> pb: int*
+        ExprStmtNode <10:3>
+          FuncCallExprNode <10:3> int
+            IdExprNode <10:3> __builtin_print: int (int)
+            ArgExprNode <10:19> int
+              UnaryExprNode <10:19> int *
+                UnaryExprNode <10:20> int* *
+                  IdExprNode <10:21> ppa: int**
+        ExprStmtNode <12:3>
+          SimpleAssignmentExprNode <12:9> int
+            UnaryExprNode <12:3> int *
+              UnaryExprNode <12:4> int* *
+                IdExprNode <12:5> ppa: int**
+            IntConstExprNode <12:11> 30: int
+        ExprStmtNode <13:3>
+          FuncCallExprNode <13:3> int
+            IdExprNode <13:3> __builtin_print: int (int)
+            ArgExprNode <13:19> int
+              IdExprNode <13:19> b: int
+        ReturnStmtNode <15:3>
+          IntConstExprNode <15:10> 0: int

--- a/test/typecheck/pointer_to_pointer_param.exp
+++ b/test/typecheck/pointer_to_pointer_param.exp
@@ -1,38 +1,40 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> add: int (int**, int**)
-    ParamNode <1:15> x: int**
-    ParamNode <1:24> y: int**
-    CompoundStmtNode <1:27>
-      ReturnStmtNode <2:3>
-        BinaryExprNode <2:14> int +
-          UnaryExprNode <2:10> int *
-            UnaryExprNode <2:11> int* *
-              IdExprNode <2:12> x: int**
-          UnaryExprNode <2:16> int *
-            UnaryExprNode <2:17> int* *
-              IdExprNode <2:18> y: int**
-  FuncDefNode <5:5> main: int ()
-    CompoundStmtNode <5:12>
-      DeclStmtNode <6:3>
-        VarDeclNode <6:7> a: int
-          IntConstExprNode <6:11> 3: int
-      DeclStmtNode <7:3>
-        VarDeclNode <7:7> b: int
-          IntConstExprNode <7:11> 5: int
-      DeclStmtNode <8:3>
-        VarDeclNode <8:8> c: int*
-          UnaryExprNode <8:12> int* &
-            IdExprNode <8:13> a: int
-      DeclStmtNode <9:3>
-        VarDeclNode <9:8> d: int*
-          UnaryExprNode <9:12> int* &
-            IdExprNode <9:13> b: int
-      ReturnStmtNode <10:3>
-        FuncCallExprNode <10:10> int
-          IdExprNode <10:10> add: int (int**, int**)
-          ArgExprNode <10:14> int**
-            UnaryExprNode <10:14> int** &
-              IdExprNode <10:15> c: int*
-          ArgExprNode <10:18> int**
-            UnaryExprNode <10:18> int** &
-              IdExprNode <10:19> d: int*
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> add: int (int**, int**)
+      ParamNode <1:15> x: int**
+      ParamNode <1:24> y: int**
+      CompoundStmtNode <1:27>
+        ReturnStmtNode <2:3>
+          BinaryExprNode <2:14> int +
+            UnaryExprNode <2:10> int *
+              UnaryExprNode <2:11> int* *
+                IdExprNode <2:12> x: int**
+            UnaryExprNode <2:16> int *
+              UnaryExprNode <2:17> int* *
+                IdExprNode <2:18> y: int**
+  ExternDeclNode <5:1>
+    FuncDefNode <5:5> main: int ()
+      CompoundStmtNode <5:12>
+        DeclStmtNode <6:3>
+          VarDeclNode <6:7> a: int
+            IntConstExprNode <6:11> 3: int
+        DeclStmtNode <7:3>
+          VarDeclNode <7:7> b: int
+            IntConstExprNode <7:11> 5: int
+        DeclStmtNode <8:3>
+          VarDeclNode <8:8> c: int*
+            UnaryExprNode <8:12> int* &
+              IdExprNode <8:13> a: int
+        DeclStmtNode <9:3>
+          VarDeclNode <9:8> d: int*
+            UnaryExprNode <9:12> int* &
+              IdExprNode <9:13> b: int
+        ReturnStmtNode <10:3>
+          FuncCallExprNode <10:10> int
+            IdExprNode <10:10> add: int (int**, int**)
+            ArgExprNode <10:14> int**
+              UnaryExprNode <10:14> int** &
+                IdExprNode <10:15> c: int*
+            ArgExprNode <10:18> int**
+              UnaryExprNode <10:18> int** &
+                IdExprNode <10:19> d: int*

--- a/test/typecheck/pointer_to_pointer_param.exp
+++ b/test/typecheck/pointer_to_pointer_param.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> add: int (int**, int**)
       ParamNode <1:15> x: int**

--- a/test/typecheck/postfix_arith_expr.exp
+++ b/test/typecheck/postfix_arith_expr.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/postfix_arith_expr.exp
+++ b/test/typecheck/postfix_arith_expr.exp
@@ -1,24 +1,25 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> a: int
-          IntConstExprNode <2:11> 0: int
-      ExprStmtNode <3:3>
-        PostfixArithExprNode <3:3> int ++
-          IdExprNode <3:3> a: int
-      ExprStmtNode <4:3>
-        PostfixArithExprNode <4:3> int --
-          IdExprNode <4:3> a: int
-      DeclStmtNode <6:3>
-        VarDeclNode <6:8> b: int*
-          UnaryExprNode <6:12> int* &
-            IdExprNode <6:13> a: int
-      ExprStmtNode <7:3>
-        PostfixArithExprNode <7:3> int* ++
-          IdExprNode <7:3> b: int*
-      ExprStmtNode <9:3>
-        PostfixArithExprNode <9:3> int* --
-          IdExprNode <9:3> b: int*
-      ReturnStmtNode <12:3>
-        IdExprNode <12:10> a: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> a: int
+            IntConstExprNode <2:11> 0: int
+        ExprStmtNode <3:3>
+          PostfixArithExprNode <3:3> int ++
+            IdExprNode <3:3> a: int
+        ExprStmtNode <4:3>
+          PostfixArithExprNode <4:3> int --
+            IdExprNode <4:3> a: int
+        DeclStmtNode <6:3>
+          VarDeclNode <6:8> b: int*
+            UnaryExprNode <6:12> int* &
+              IdExprNode <6:13> a: int
+        ExprStmtNode <7:3>
+          PostfixArithExprNode <7:3> int* ++
+            IdExprNode <7:3> b: int*
+        ExprStmtNode <9:3>
+          PostfixArithExprNode <9:3> int* --
+            IdExprNode <9:3> b: int*
+        ReturnStmtNode <12:3>
+          IdExprNode <12:10> a: int

--- a/test/typecheck/return_stmt.exp
+++ b/test/typecheck/return_stmt.exp
@@ -1,5 +1,6 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      ReturnStmtNode <2:3>
-        IntConstExprNode <2:10> 0: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        ReturnStmtNode <2:3>
+          IntConstExprNode <2:10> 0: int

--- a/test/typecheck/return_stmt.exp
+++ b/test/typecheck/return_stmt.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/struct.exp
+++ b/test/typecheck/struct.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/struct.exp
+++ b/test/typecheck/struct.exp
@@ -1,55 +1,56 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        RecordDeclNode <2:10> struct ss definition
-      DeclStmtNode <4:3>
-        RecordDeclNode <4:10> struct birth definition
-          FieldNode <5:9> date: int
-          FieldNode <6:9> month: int
-          FieldNode <7:9> year: int
-      DeclStmtNode <10:3>
-        RecordDeclNode <10:9> struct definition
-          FieldNode <11:9> quarter: int
-          FieldNode <12:9> dime: int
-          FieldNode <13:9> penny: int
-      DeclStmtNode <16:3>
-        RecordVarDeclNode <16:16> bd1: struct birth
-          InitExprNode <17:5> int
-            IdDesNode <17:6> date
-            IntConstExprNode <17:13> 1: int
-          InitExprNode <17:5> int
-            IdDesNode <18:6> month
-            IntConstExprNode <18:14> 1: int
-          InitExprNode <17:5> int
-            IdDesNode <19:6> year
-            IntConstExprNode <19:13> 1995: int
-      DeclStmtNode <22:3>
-        RecordVarDeclNode <22:16> bd2: struct birth
-          InitExprNode <22:23> int
-            IntConstExprNode <22:23> 3: int
-          InitExprNode <22:23> int
-            IntConstExprNode <22:26> 3: int
-          InitExprNode <22:23> int
-            IntConstExprNode <22:29> 1998: int
-      DeclStmtNode <24:3>
-        ArrDeclNode <24:16> bd3: struct birth[3]
-          InitExprNode <24:26> int
-            ArrDesNode <24:27>
-              IntConstExprNode <24:27> 0: int
-            IdDesNode <24:30> date
-            IntConstExprNode <24:37> 4: int
-          InitExprNode <24:26> int
-            ArrDesNode <24:41>
-              IntConstExprNode <24:41> 1: int
-            IdDesNode <24:44> year
-            IntConstExprNode <24:51> 1999: int
-      DeclStmtNode <26:3>
-        VarDeclNode <26:16> a: struct birth
-        VarDeclNode <26:20> b: struct birth*
-        ArrDeclNode <26:23> c: struct birth[3]
-      ExprStmtNode <28:3>
-        RecordMemExprNode <28:3> .date: int
-          IdExprNode <28:3> bd1: struct birth
-      ReturnStmtNode <30:3>
-        IntConstExprNode <30:10> 0: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          RecordDeclNode <2:10> struct ss definition
+        DeclStmtNode <4:3>
+          RecordDeclNode <4:10> struct birth definition
+            FieldNode <5:9> date: int
+            FieldNode <6:9> month: int
+            FieldNode <7:9> year: int
+        DeclStmtNode <10:3>
+          RecordDeclNode <10:9> struct definition
+            FieldNode <11:9> quarter: int
+            FieldNode <12:9> dime: int
+            FieldNode <13:9> penny: int
+        DeclStmtNode <16:3>
+          RecordVarDeclNode <16:16> bd1: struct birth
+            InitExprNode <17:5> int
+              IdDesNode <17:6> date
+              IntConstExprNode <17:13> 1: int
+            InitExprNode <17:5> int
+              IdDesNode <18:6> month
+              IntConstExprNode <18:14> 1: int
+            InitExprNode <17:5> int
+              IdDesNode <19:6> year
+              IntConstExprNode <19:13> 1995: int
+        DeclStmtNode <22:3>
+          RecordVarDeclNode <22:16> bd2: struct birth
+            InitExprNode <22:23> int
+              IntConstExprNode <22:23> 3: int
+            InitExprNode <22:23> int
+              IntConstExprNode <22:26> 3: int
+            InitExprNode <22:23> int
+              IntConstExprNode <22:29> 1998: int
+        DeclStmtNode <24:3>
+          ArrDeclNode <24:16> bd3: struct birth[3]
+            InitExprNode <24:26> int
+              ArrDesNode <24:27>
+                IntConstExprNode <24:27> 0: int
+              IdDesNode <24:30> date
+              IntConstExprNode <24:37> 4: int
+            InitExprNode <24:26> int
+              ArrDesNode <24:41>
+                IntConstExprNode <24:41> 1: int
+              IdDesNode <24:44> year
+              IntConstExprNode <24:51> 1999: int
+        DeclStmtNode <26:3>
+          VarDeclNode <26:16> a: struct birth
+          VarDeclNode <26:20> b: struct birth*
+          ArrDeclNode <26:23> c: struct birth[3]
+        ExprStmtNode <28:3>
+          RecordMemExprNode <28:3> .date: int
+            IdExprNode <28:3> bd1: struct birth
+        ReturnStmtNode <30:3>
+          IntConstExprNode <30:10> 0: int

--- a/test/typecheck/switch_stmt.exp
+++ b/test/typecheck/switch_stmt.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/switch_stmt.exp
+++ b/test/typecheck/switch_stmt.exp
@@ -1,30 +1,31 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> a: int
-          IntConstExprNode <2:11> 1: int
-      SwitchStmtNode <3:3>
-        IdExprNode <3:11> a: int
-        CompoundStmtNode <3:14>
-          CaseStmtNode <4:5>
-            IntConstExprNode <4:10> 1: int
-            ExprStmtNode <5:7>
-              SimpleAssignmentExprNode <5:9> int
-                IdExprNode <5:7> a: int
-                IntConstExprNode <5:11> 2: int
-          BreakStmtNode <6:7>
-          CaseStmtNode <7:5>
-            IntConstExprNode <7:10> 2: int
-            ExprStmtNode <8:7>
-              SimpleAssignmentExprNode <8:9> int
-                IdExprNode <8:7> a: int
-                IntConstExprNode <8:11> 3: int
-          BreakStmtNode <9:7>
-          DefaultStmtNode <10:5>
-            ExprStmtNode <11:7>
-              SimpleAssignmentExprNode <11:9> int
-                IdExprNode <11:7> a: int
-                IntConstExprNode <11:11> 4: int
-      ReturnStmtNode <13:3>
-        IdExprNode <13:10> a: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> a: int
+            IntConstExprNode <2:11> 1: int
+        SwitchStmtNode <3:3>
+          IdExprNode <3:11> a: int
+          CompoundStmtNode <3:14>
+            CaseStmtNode <4:5>
+              IntConstExprNode <4:10> 1: int
+              ExprStmtNode <5:7>
+                SimpleAssignmentExprNode <5:9> int
+                  IdExprNode <5:7> a: int
+                  IntConstExprNode <5:11> 2: int
+            BreakStmtNode <6:7>
+            CaseStmtNode <7:5>
+              IntConstExprNode <7:10> 2: int
+              ExprStmtNode <8:7>
+                SimpleAssignmentExprNode <8:9> int
+                  IdExprNode <8:7> a: int
+                  IntConstExprNode <8:11> 3: int
+            BreakStmtNode <9:7>
+            DefaultStmtNode <10:5>
+              ExprStmtNode <11:7>
+                SimpleAssignmentExprNode <11:9> int
+                  IdExprNode <11:7> a: int
+                  IntConstExprNode <11:11> 4: int
+        ReturnStmtNode <13:3>
+          IdExprNode <13:10> a: int

--- a/test/typecheck/unary_expr.exp
+++ b/test/typecheck/unary_expr.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/unary_expr.exp
+++ b/test/typecheck/unary_expr.exp
@@ -1,34 +1,35 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> i: int
-          IntConstExprNode <2:11> 1: int
-      ExprStmtNode <3:3>
-        UnaryExprNode <3:3> int --
-          IdExprNode <3:5> i: int
-      ExprStmtNode <4:3>
-        UnaryExprNode <4:3> int ++
-          IdExprNode <4:5> i: int
-      ExprStmtNode <5:3>
-        SimpleAssignmentExprNode <5:5> int
-          IdExprNode <5:3> i: int
-          UnaryExprNode <5:7> int +
-            IdExprNode <5:8> i: int
-      ExprStmtNode <6:3>
-        SimpleAssignmentExprNode <6:5> int
-          IdExprNode <6:3> i: int
-          UnaryExprNode <6:7> int -
-            IdExprNode <6:8> i: int
-      ExprStmtNode <7:3>
-        SimpleAssignmentExprNode <7:5> int
-          IdExprNode <7:3> i: int
-          UnaryExprNode <7:7> int !
-            IdExprNode <7:8> i: int
-      ExprStmtNode <8:3>
-        SimpleAssignmentExprNode <8:5> int
-          IdExprNode <8:3> i: int
-          UnaryExprNode <8:7> int ~
-            IdExprNode <8:8> i: int
-      ReturnStmtNode <10:3>
-        IntConstExprNode <10:10> 0: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> i: int
+            IntConstExprNode <2:11> 1: int
+        ExprStmtNode <3:3>
+          UnaryExprNode <3:3> int --
+            IdExprNode <3:5> i: int
+        ExprStmtNode <4:3>
+          UnaryExprNode <4:3> int ++
+            IdExprNode <4:5> i: int
+        ExprStmtNode <5:3>
+          SimpleAssignmentExprNode <5:5> int
+            IdExprNode <5:3> i: int
+            UnaryExprNode <5:7> int +
+              IdExprNode <5:8> i: int
+        ExprStmtNode <6:3>
+          SimpleAssignmentExprNode <6:5> int
+            IdExprNode <6:3> i: int
+            UnaryExprNode <6:7> int -
+              IdExprNode <6:8> i: int
+        ExprStmtNode <7:3>
+          SimpleAssignmentExprNode <7:5> int
+            IdExprNode <7:3> i: int
+            UnaryExprNode <7:7> int !
+              IdExprNode <7:8> i: int
+        ExprStmtNode <8:3>
+          SimpleAssignmentExprNode <8:5> int
+            IdExprNode <8:3> i: int
+            UnaryExprNode <8:7> int ~
+              IdExprNode <8:8> i: int
+        ReturnStmtNode <10:3>
+          IntConstExprNode <10:10> 0: int

--- a/test/typecheck/union.exp
+++ b/test/typecheck/union.exp
@@ -1,56 +1,57 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        RecordDeclNode <2:9> union u definition
-      DeclStmtNode <4:3>
-        RecordDeclNode <4:9> union shape definition
-          FieldNode <5:9> square: int
-          FieldNode <6:9> circle: int
-          FieldNode <7:9> triangle: int
-      DeclStmtNode <10:3>
-        RecordDeclNode <10:8> union definition
-          FieldNode <11:9> a: int
-          FieldNode <12:9> b: int
-          FieldNode <13:9> c: int
-          FieldNode <14:9> d: int
-          FieldNode <15:9> e: int
-      DeclStmtNode <20:3>
-        RecordVarDeclNode <20:15> s: union shape
-          InitExprNode <20:20> int
-            IntConstExprNode <20:20> 3: int
-          InitExprNode <20:20> int
-            IntConstExprNode <20:23> 4: int
-          InitExprNode <20:20> int
-            IntConstExprNode <20:26> 5: int
-      DeclStmtNode <22:3>
-        RecordVarDeclNode <22:15> circle: union shape
-          InitExprNode <22:25> int
-            IdDesNode <22:26> circle
-            IntConstExprNode <22:35> 1: int
-      DeclStmtNode <23:3>
-        ArrDeclNode <23:15> puzzles: union shape[3]
-          InitExprNode <23:29> int
-            ArrDesNode <23:30>
-              IntConstExprNode <23:30> 0: int
-            IdDesNode <23:33> circle
-            IntConstExprNode <23:42> 1: int
-          InitExprNode <23:29> int
-            ArrDesNode <23:46>
-              IntConstExprNode <23:46> 1: int
-            IdDesNode <23:49> triangle
-            IntConstExprNode <23:60> 2: int
-          InitExprNode <23:29> int
-            ArrDesNode <23:64>
-              IntConstExprNode <23:64> 2: int
-            IdDesNode <23:67> square
-            IntConstExprNode <23:76> 4: int
-      DeclStmtNode <25:3>
-        VarDeclNode <25:15> a: union shape
-        VarDeclNode <25:19> b: union shape*
-        ArrDeclNode <25:22> c: union shape[3]
-      ExprStmtNode <27:3>
-        RecordMemExprNode <27:3> .circle: int
-          IdExprNode <27:3> s: union shape
-      ReturnStmtNode <29:3>
-        IntConstExprNode <29:10> 0: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          RecordDeclNode <2:9> union u definition
+        DeclStmtNode <4:3>
+          RecordDeclNode <4:9> union shape definition
+            FieldNode <5:9> square: int
+            FieldNode <6:9> circle: int
+            FieldNode <7:9> triangle: int
+        DeclStmtNode <10:3>
+          RecordDeclNode <10:8> union definition
+            FieldNode <11:9> a: int
+            FieldNode <12:9> b: int
+            FieldNode <13:9> c: int
+            FieldNode <14:9> d: int
+            FieldNode <15:9> e: int
+        DeclStmtNode <20:3>
+          RecordVarDeclNode <20:15> s: union shape
+            InitExprNode <20:20> int
+              IntConstExprNode <20:20> 3: int
+            InitExprNode <20:20> int
+              IntConstExprNode <20:23> 4: int
+            InitExprNode <20:20> int
+              IntConstExprNode <20:26> 5: int
+        DeclStmtNode <22:3>
+          RecordVarDeclNode <22:15> circle: union shape
+            InitExprNode <22:25> int
+              IdDesNode <22:26> circle
+              IntConstExprNode <22:35> 1: int
+        DeclStmtNode <23:3>
+          ArrDeclNode <23:15> puzzles: union shape[3]
+            InitExprNode <23:29> int
+              ArrDesNode <23:30>
+                IntConstExprNode <23:30> 0: int
+              IdDesNode <23:33> circle
+              IntConstExprNode <23:42> 1: int
+            InitExprNode <23:29> int
+              ArrDesNode <23:46>
+                IntConstExprNode <23:46> 1: int
+              IdDesNode <23:49> triangle
+              IntConstExprNode <23:60> 2: int
+            InitExprNode <23:29> int
+              ArrDesNode <23:64>
+                IntConstExprNode <23:64> 2: int
+              IdDesNode <23:67> square
+              IntConstExprNode <23:76> 4: int
+        DeclStmtNode <25:3>
+          VarDeclNode <25:15> a: union shape
+          VarDeclNode <25:19> b: union shape*
+          ArrDeclNode <25:22> c: union shape[3]
+        ExprStmtNode <27:3>
+          RecordMemExprNode <27:3> .circle: int
+            IdExprNode <27:3> s: union shape
+        ReturnStmtNode <29:3>
+          IntConstExprNode <29:10> 0: int

--- a/test/typecheck/union.exp
+++ b/test/typecheck/union.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/while_single_stmt.exp
+++ b/test/typecheck/while_single_stmt.exp
@@ -1,20 +1,21 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> i: int
-          IntConstExprNode <2:11> 5: int
-      WhileStmtNode <3:3>
-        // While
-        BinaryExprNode <3:12> int >
-          IdExprNode <3:10> i: int
-          IntConstExprNode <3:14> 0: int
-        // Body
-        ExprStmtNode <4:5>
-          SimpleAssignmentExprNode <4:7> int
-            IdExprNode <4:5> i: int
-            BinaryExprNode <4:11> int -
-              IdExprNode <4:9> i: int
-              IntConstExprNode <4:13> 1: int
-      ReturnStmtNode <6:3>
-        IdExprNode <6:10> i: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> i: int
+            IntConstExprNode <2:11> 5: int
+        WhileStmtNode <3:3>
+          // While
+          BinaryExprNode <3:12> int >
+            IdExprNode <3:10> i: int
+            IntConstExprNode <3:14> 0: int
+          // Body
+          ExprStmtNode <4:5>
+            SimpleAssignmentExprNode <4:7> int
+              IdExprNode <4:5> i: int
+              BinaryExprNode <4:11> int -
+                IdExprNode <4:9> i: int
+                IntConstExprNode <4:13> 1: int
+        ReturnStmtNode <6:3>
+          IdExprNode <6:10> i: int

--- a/test/typecheck/while_single_stmt.exp
+++ b/test/typecheck/while_single_stmt.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/while_stmt.exp
+++ b/test/typecheck/while_stmt.exp
@@ -1,4 +1,4 @@
-ProgramNode <1:1>
+TransUnitNode <1:1>
   ExternDeclNode <1:1>
     FuncDefNode <1:5> main: int ()
       CompoundStmtNode <1:12>

--- a/test/typecheck/while_stmt.exp
+++ b/test/typecheck/while_stmt.exp
@@ -1,21 +1,22 @@
 ProgramNode <1:1>
-  FuncDefNode <1:5> main: int ()
-    CompoundStmtNode <1:12>
-      DeclStmtNode <2:3>
-        VarDeclNode <2:7> i: int
-          IntConstExprNode <2:11> 5: int
-      WhileStmtNode <3:3>
-        // While
-        BinaryExprNode <3:12> int >
-          IdExprNode <3:10> i: int
-          IntConstExprNode <3:14> 0: int
-        // Body
-        CompoundStmtNode <3:17>
-          ExprStmtNode <4:5>
-            SimpleAssignmentExprNode <4:7> int
-              IdExprNode <4:5> i: int
-              BinaryExprNode <4:11> int -
-                IdExprNode <4:9> i: int
-                IntConstExprNode <4:13> 1: int
-      ReturnStmtNode <7:3>
-        IntConstExprNode <7:10> 0: int
+  ExternDeclNode <1:1>
+    FuncDefNode <1:5> main: int ()
+      CompoundStmtNode <1:12>
+        DeclStmtNode <2:3>
+          VarDeclNode <2:7> i: int
+            IntConstExprNode <2:11> 5: int
+        WhileStmtNode <3:3>
+          // While
+          BinaryExprNode <3:12> int >
+            IdExprNode <3:10> i: int
+            IntConstExprNode <3:14> 0: int
+          // Body
+          CompoundStmtNode <3:17>
+            ExprStmtNode <4:5>
+              SimpleAssignmentExprNode <4:7> int
+                IdExprNode <4:5> i: int
+                BinaryExprNode <4:11> int -
+                  IdExprNode <4:9> i: int
+                  IntConstExprNode <4:13> 1: int
+        ReturnStmtNode <7:3>
+          IntConstExprNode <7:10> 0: int


### PR DESCRIPTION
- Introduce `ExternDeclNode` for global variable and function definition. 
- Since we don't support obsolete function definition, it's quite straight forward to add grammar for supporting global variables. I kept node `ProgramNode` as our root node, let me know if you think it's better to rename it to `TransUnitNode` or some other name. I prefer keeping `ProgramNode` since we are doing some internal initialization in that node. This separate our internal logic from the AST node.
- Move the logic of checking `main` function to `FuncDefNode` because ExternDeclNode can possibly be `DeclStmtNode`.

```
translation_unit : external_declaration
	| translation_unit external_declaration

external_declaration: function_definition
	| declaration
	;
```