### PR TITLE
Check tidy entirely on PR & diff on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -q -y clang-tidy-18
       - name: static checks on diff
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'push' }}
         run: |
           export CLANG_TIDY_DIFF=clang-tidy-diff-18.py
           scripts/check-tidy-diff.sh
       - name: static checks
-        if : ${{ github.event_name == 'push' }}
+        if : ${{ github.event_name == 'pull_request' }}
         run: |
           export CLANG_TIDY=clang-tidy-18
           make tidy


### PR DESCRIPTION
This addresses the issue where missing includes are not caught until being merged. For a single push, we check the diff to ensure it doesn't introduce serious tidy issues. The diff check is relatively lightweight. For a PR, we perform a thorough check on the entire program to ensure everything is fine before merging into the codebase.