### PR TITLE
Separate CI tests for QBE and LLVM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
     strategy:
       matrix:
         cxx: [g++, clang++]
+        test: [typecheck, qbe, llvm]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
@@ -64,5 +65,7 @@ jobs:
         run: scripts/install-fmt.sh
       - name: Install Turnt
         run: pip install turnt
-      - name: Run tests
-        run: make test CXX=${{ matrix.cxx }}
+      - name: Build
+        run: make
+      - name: Run ${{ matrix.test }} test
+        run: make -C test/ -j test-${{ matrix.test }} CXX=${{ matrix.cxx }}

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ DEPS = $(OBJS:.o=.d)
 all: $(TARGET)
 
 test: $(TARGET)
-	$(MAKE) -C test/ test
+	$(MAKE) -C test/ test-all
+	@echo "NOTE: If you want to run individual tests, check 'test/Makefile'."
 
 $(TARGET): $(OBJS)
 	$(CXX) $(CXXFLAGS) $(OBJS) -o $@ $(LDLIBS)

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,14 +1,16 @@
 .PHONY: test clean
 
+TURNTFLAGS = --diff
+
 test:
 	@# NOTE: The -j option is added to MAKEFLAGS only when entering the recipe.
 	@# Therefore, we have to check it here.
 	@case "$(MAKEFLAGS)" in \
 		*j*) \
-			turnt **/*.c --diff -j; \
+			turnt **/*.c $(TURNTFLAGS) -j; \
 			;; \
 		*) \
-			turnt **/*.c --diff; \
+			turnt **/*.c $(TURNTFLAGS); \
 			;; \
 	esac
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,8 +1,11 @@
-.PHONY: test clean
+.PHONY: test-all test-typecheck test-qbe test-llvm clean
 
 TURNTFLAGS = --diff
 
-test:
+
+# NOTE: Not placing individual test targets as the dependencies so that the tests
+# are not aborted if any of the individual tests fail.
+test-all:
 	@# NOTE: The -j option is added to MAKEFLAGS only when entering the recipe.
 	@# Therefore, we have to check it here.
 	@case "$(MAKEFLAGS)" in \
@@ -14,6 +17,36 @@ test:
 			;; \
 	esac
 
+test-typecheck:
+	@case "$(MAKEFLAGS)" in \
+		*j*) \
+			turnt typecheck/*.c $(TURNTFLAGS) -j; \
+			;; \
+		*) \
+			turnt typecheck/*.c $(TURNTFLAGS); \
+			;; \
+	esac
+
+test-qbe:
+	@case "$(MAKEFLAGS)" in \
+		*j*) \
+			turnt codegen/*.c --env qbe $(TURNTFLAGS) -j; \
+			;; \
+		*) \
+			turnt codegen/*.c --env qbe $(TURNTFLAGS); \
+			;; \
+	esac
+
+test-llvm:
+	@case "$(MAKEFLAGS)" in \
+		*j*) \
+			turnt codegen/*.c --env llvm $(TURNTFLAGS) -j; \
+			;; \
+		*) \
+			turnt codegen/*.c --env llvm $(TURNTFLAGS); \
+			;; \
+	esac
+
 
 clean:
-	rm -f *.s **/*.s *.o **/*.o *.ssa **/*.ssa **/*.ll
+	$(RM) *.s **/*.s *.o **/*.o *.ssa **/*.ssa **/*.ll


### PR DESCRIPTION
Currently, we have three types of tests:
- Typecheck
- QBE codegen
- LLVM codegen

These tests are run together in CI, making it difficult to identify which part is causing a failure. This PR separates these tests into individual Makefile targets so they can be run independently in CI. The behavior of `make test` remains unchanged, as it will still run all tests.