### PR TITLE
Reduce ad-hoc type conversions on functions

### DIFF
--- a/include/llvm/util.hpp
+++ b/include/llvm/util.hpp
@@ -41,9 +41,6 @@ class LLVMIRBuilderHelper {
   llvm::Function* CurrFunc();
 
   /// @brief Get the corresponding LLVM type from our type.
-  /// @note For Function Pointers, even though it is a pointer type, we return
-  /// `FunctionType` instead of `PointerType` because `FunctionType` is needed
-  /// for creating LLVM IR function call.
   /// @throw `std::runtime_error` if the `type` is not unknown.
   llvm::Type* GetLLVMType(const Type& type);
 

--- a/src/llvm/util.cpp
+++ b/src/llvm/util.cpp
@@ -60,13 +60,6 @@ llvm::Type* LLVMIRBuilderHelper::GetLLVMType(const Type& type) {
     }
     throw std::runtime_error{"unknown type in GetLLVMType!"};
   } else if (type.IsPtr()) {
-    auto ptr_type = dynamic_cast<const PtrType*>(&type);
-    auto base_type = ptr_type->base_type().Clone();
-    auto llvm_base_type = GetLLVMType(*base_type);
-    // Function pointers
-    if (llvm_base_type->isFunctionTy()) {
-      return llvm_base_type;
-    }
     return builder_.getPtrTy();
   } else if (type.IsArr()) {
     auto arr_type = dynamic_cast<const ArrType*>(&type);


### PR DESCRIPTION
By not treating function pointers specially in `GetLLVMType`, most of the ad-hoc conversions from function types to pointer types are eliminated. The only remaining conversion is when referencing the ID of a function; the type of such ID expression should be a pointer type instead of a function type. Additionally, when using such an ID expression in a function call, we need to convert it back to a function type.