### PR TITLE
Use dynamic cast on reference when should not fail

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -423,15 +423,15 @@ decl: declaration_specifiers init_declarator_list_opt SEMICOLON {
       // A record declaration that doesn't declare any identifier, e.g., `struct point {int x, int y};`.
       if (init_decl_list.empty()) {
         decl_list.push_back(std::move(decl));
-      }
-
-      auto& rec_decl = dynamic_cast<RecordDeclNode&>(*decl);
-      // Initialize record variable.
-      for (auto& init_decl : init_decl_list) {
-        if (init_decl) {
-          init_decl->type = ResolveType(rec_decl.type->Clone(), std::move(init_decl->type));
+      } else {
+        auto& rec_decl = dynamic_cast<RecordDeclNode&>(*decl);
+        // Initialize record variable.
+        for (auto& init_decl : init_decl_list) {
+          if (init_decl) {
+            init_decl->type = ResolveType(rec_decl.type->Clone(), std::move(init_decl->type));
+          }
+          decl_list.push_back(std::move(init_decl));
         }
-        decl_list.push_back(std::move(init_decl));
       }
     }
     $$ = std::make_unique<DeclStmtNode>(Loc(@1), std::move(decl_list));


### PR DESCRIPTION
There is a common pattern in our code where we dynamically cast a pointer and assert that it is not null. This pattern implies that the cast should not fail. Therefore, we can use the reference version of dynamic casting, which throws a `std::bad_cast` exception if the cast fails.
Additionally, we are using dynamic casting with unique pointers, which requires a manual `get()` to obtain the underlying pointer. Since `get()` should only be used when necessary, this change also eliminates its use.
Notice that `static_cast` has been replaced by `dynamic_cast`. This is because there is a concern that the static cast might not be valid, so we are still relying on the dynamic check.

> [!NOTE]
> The remaining use cases are those where we use dynamic checks with an `if` to verify whether an object is of a certain type, which is expected to fail.